### PR TITLE
new structure of relay

### DIFF
--- a/rings-core/src/dht/stabilization.rs
+++ b/rings-core/src/dht/stabilization.rs
@@ -42,10 +42,11 @@ impl Stabilization {
             Message::NotifyPredecessorSend(NotifyPredecessorSend { id: chord.id }),
             &self.swarm.session_manager,
             OriginVerificationGen::Origin,
-            None,
-            None,
-            None,
             MessageRelayMethod::SEND,
+            None,
+            None,
+            None,
+            self.swarm.address().into(),
         )?;
         if chord.id != chord.successor.min() {
             for s in chord.successor.list() {
@@ -76,10 +77,11 @@ impl Stabilization {
                         }),
                         &self.swarm.session_manager,
                         OriginVerificationGen::Origin,
-                        None,
-                        None,
-                        None,
                         MessageRelayMethod::SEND,
+                        None,
+                        None,
+                        None,
+                        self.swarm.address().into(),
                     )?;
                     self.swarm.send_message(&next.into(), message).await
                 }

--- a/rings-core/src/err.rs
+++ b/rings-core/src/err.rs
@@ -78,7 +78,7 @@ pub enum Error {
     #[error("Receive `AlreadyConnected`` but cannot get transport")]
     MessageHandlerMissTransportAlreadyConnected,
 
-    #[error("Cannot get trans while handle connect node response")]
+    #[error("Cannot get trans when handle connect node response")]
     MessageHandlerMissTransportConnectedNode,
 
     #[error("Send message through channel failed")]
@@ -120,7 +120,7 @@ pub enum Error {
     #[error("transport not found")]
     SwarmPendingTransNotFound,
 
-    #[error("failed to close previous while registering, {0}")]
+    #[error("failed to close previous when registering, {0}")]
     SwarmToClosePrevTransport(String),
 
     #[error("call lock() failed")]
@@ -211,6 +211,27 @@ pub enum Error {
 
     #[error("Failed to decrypt data")]
     DecryptionError,
+
+    #[error("Current node is not the next hop of message")]
+    InvalidNextHop,
+
+    #[error("Adjacent elements in path cannot be equal")]
+    InvalidRelayPath,
+
+    #[error("The destination of report message should always be the first element of path")]
+    InvalidRelayDestination,
+
+    #[error("Cannot infer next hop")]
+    CannotInferNextHop,
+
+    #[error("Cannot get next hop when sending message")]
+    NoNextHop,
+
+    #[error("To generate REPORT, you should provide SEND")]
+    ReportNeedSend,
+
+    #[error("Only SEND message can reset destination")]
+    ResetDestinationNeedSend,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/rings-core/src/message/handlers/mod.rs
+++ b/rings-core/src/message/handlers/mod.rs
@@ -413,9 +413,9 @@ pub mod test {
 
         handler1
             .send_message(
+                &addr2.into(),
+                &addr2.into(),
                 Message::custom("Hello world 1", &None)?,
-                Some(addr2.into()),
-                addr2.into(),
             )
             .await
             .unwrap();

--- a/rings-core/src/message/handlers/mod.rs
+++ b/rings-core/src/message/handlers/mod.rs
@@ -11,7 +11,6 @@ use async_recursion::async_recursion;
 use async_trait::async_trait;
 use connection::TChordConnection;
 use futures::lock::Mutex;
-use std::collections::VecDeque;
 use std::sync::Arc;
 use storage::TChordStorage;
 use web3::types::Address;
@@ -76,56 +75,39 @@ impl MessageHandler {
         *cb = Some(f)
     }
 
-    pub async fn send_relay_message(
-        &self,
-        address: &Address,
-        msg: MessageRelay<Message>,
-    ) -> Result<()> {
+    pub async fn send_relay_message(&self, msg: MessageRelay<Message>) -> Result<()> {
         #[cfg(test)]
         {
             println!("+++++++++++++++++++++++++++++++++");
             println!("node {:?}", self.swarm.address());
             println!("Sent {:?}", msg.clone());
-            println!("node {:?}", address);
+            println!("node {:?}", msg.next_hop);
             println!("+++++++++++++++++++++++++++++++++");
         }
-        self.swarm.send_message(address, msg).await
-    }
-
-    pub async fn send_message_default(&self, address: &Address, message: Message) -> Result<()> {
-        self.send_message(
-            address,
-            None,
-            None,
-            MessageRelayMethod::SEND,
-            OriginVerificationGen::Origin,
-            message,
-        )
-        .await
+        if let Some(id) = msg.next_hop {
+            self.swarm.send_message(&id.into(), msg).await
+        } else {
+            Err(Error::NoNextHop)
+        }
     }
 
     pub async fn send_message(
         &self,
-        address: &Address,
-        to_path: Option<VecDeque<Did>>,
-        from_path: Option<VecDeque<Did>>,
-        method: MessageRelayMethod,
-        origin_verification_gen: OriginVerificationGen,
-        message: Message,
+        next_hop: &Did,
+        destination: &Did,
+        msg: Message,
     ) -> Result<()> {
-        let from_path = from_path.unwrap_or_else(|| vec![self.swarm.address().into()].into());
-        let to_path = to_path.unwrap_or_else(|| vec![(*address).into()].into());
-
-        let payload = MessageRelay::new(
-            message,
+        self.send_relay_message(MessageRelay::new(
+            msg,
             &self.swarm.session_manager,
-            origin_verification_gen,
+            OriginVerificationGen::Origin,
+            MessageRelayMethod::SEND,
             None,
-            Some(to_path),
-            Some(from_path),
-            method,
-        )?;
-        self.send_relay_message(address, payload).await
+            None,
+            Some(*next_hop),
+            *destination,
+        )?)
+        .await
     }
 
     // disconnect a node if a node is in DHT
@@ -136,27 +118,28 @@ impl MessageHandler {
     }
 
     pub async fn connect(&self, address: &Address) -> Result<()> {
+        let target_id = address.to_owned().into();
         let transport = self.swarm.new_transport().await?;
         let handshake_info = transport
             .get_handshake_info(&self.swarm.session_manager, RTCSdpType::Offer)
             .await?;
         let connect_msg = Message::ConnectNodeSend(super::ConnectNodeSend {
             sender_id: self.swarm.address().into(),
-            target_id: address.to_owned().into(),
+            target_id,
             transport_uuid: transport.id.to_string(),
             handshake_info: handshake_info.to_string(),
         });
-        let target = self.dht.lock().await.successor.max();
-        self.send_message(
-            &target,
-            // to_path
-            Some(vec![target].into()),
-            // from_path
-            Some(vec![self.swarm.address().into()].into()),
-            MessageRelayMethod::SEND,
-            OriginVerificationGen::Origin,
+        let next_hop = self.dht.lock().await.successor.max();
+        self.send_relay_message(MessageRelay::new(
             connect_msg,
-        )
+            &self.swarm.session_manager,
+            OriginVerificationGen::Origin,
+            MessageRelayMethod::SEND,
+            None,
+            None,
+            Some(next_hop),
+            target_id,
+        )?)
         .await?;
         self.swarm.push_pending_transport(&transport)
     }
@@ -212,14 +195,10 @@ impl MessageHandler {
             Message::StoreVNode(msg) => self.store_vnode(relay.clone(), prev, msg).await,
             Message::MultiCall(msg) => {
                 for message in msg.messages {
-                    let payload = MessageRelay::new(
-                        message.clone(),
+                    let payload = relay.rewrap(
+                        message,
                         &self.swarm.session_manager,
                         OriginVerificationGen::Stick(relay.origin_verification.clone()),
-                        None,
-                        Some(relay.to_path.clone()),
-                        Some(relay.from_path.clone()),
-                        relay.method.clone(),
                     )?;
                     self.handle_message_relay(payload, prev).await.unwrap_or(());
                 }
@@ -433,7 +412,11 @@ pub mod test {
         handler2.set_callback(cb2).await;
 
         handler1
-            .send_message_default(&addr2, Message::custom("Hello world 1", &None)?)
+            .send_message(
+                Message::custom("Hello world 1", &None)?,
+                Some(addr2.into()),
+                addr2.into(),
+            )
             .await
             .unwrap();
 

--- a/rings-core/src/message/payload.rs
+++ b/rings-core/src/message/payload.rs
@@ -263,19 +263,19 @@ where
 }
 
 #[cfg(test)]
-mod tests {
+pub mod test {
     use super::*;
     use crate::ecc::SecretKey;
 
-    #[derive(Deserialize, Serialize, PartialEq, Debug)]
-    struct TestData {
+    #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
+    pub struct TestData {
         a: String,
         b: i64,
         c: f64,
         d: bool,
     }
 
-    fn new_test_message() -> MessageRelay<TestData> {
+    pub fn new_test_message() -> MessageRelay<TestData> {
         let key = SecretKey::random();
         let destination = SecretKey::random().address().into();
         let session = SessionManager::new_with_seckey(&key).unwrap();
@@ -312,9 +312,9 @@ mod tests {
 
         let relaied_payload = payload
             .rewrap(
-                payload.data,
+                payload.data.clone(),
                 &session2,
-                OriginVerificationGen::Stick(payload.origin_verification),
+                OriginVerificationGen::Stick(payload.origin_verification.clone()),
             )
             .unwrap();
 

--- a/rings-core/src/message/payload.rs
+++ b/rings-core/src/message/payload.rs
@@ -1,6 +1,8 @@
+use super::encoder::{Decoder, Encoded, Encoder};
 use crate::dht::Did;
 use crate::ecc::{signers, HashStr, PublicKey};
 use crate::err::{Error, Result};
+use crate::message::protocol::MessageSessionRelayProtocol;
 use crate::session::SessionManager;
 use crate::session::{Session, Signer};
 use crate::utils;
@@ -9,11 +11,8 @@ use flate2::Compression;
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde::Serialize;
-use std::collections::VecDeque;
 use std::io::Write;
 use web3::types::Address;
-
-use super::encoder::{Decoder, Encoded, Encoder};
 
 const DEFAULT_TTL_MS: usize = 60 * 1000;
 
@@ -40,12 +39,18 @@ pub struct MessageVerification {
 pub struct MessageRelay<T> {
     pub data: T,
     pub tx_id: HashStr,
-    pub to_path: VecDeque<Did>,
-    pub from_path: VecDeque<Did>,
     pub addr: Address,
+
+    // verification
     pub relay_verification: MessageVerification,
     pub origin_verification: MessageVerification,
+
+    // relay
     pub method: MessageRelayMethod,
+    pub path: Vec<Did>,
+    pub path_end_cursor: usize,
+    pub next_hop: Option<Did>,
+    pub destination: Did,
 }
 
 impl MessageVerification {
@@ -99,23 +104,25 @@ impl<T> MessageRelay<T>
 where
     T: Serialize + DeserializeOwned,
 {
+    // TODO: split verification and relay out
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         data: T,
         session_manager: &SessionManager,
         origin_verification_gen: OriginVerificationGen,
-        ttl_ms: Option<usize>,
-        to_path: Option<VecDeque<Did>>,
-        from_path: Option<VecDeque<Did>>,
         method: MessageRelayMethod,
+        path: Option<Vec<Did>>,
+        path_end_cursor: Option<usize>,
+        next_hop: Option<Did>,
+        destination: Did,
     ) -> Result<Self> {
         let ts_ms = utils::get_epoch_ms();
-        let ttl_ms = ttl_ms.unwrap_or(DEFAULT_TTL_MS);
+        let ttl_ms = DEFAULT_TTL_MS;
         let msg = &MessageVerification::pack_msg(&data, ts_ms, ttl_ms)?;
         let tx_id = msg.into();
         let addr = session_manager.authorizer()?.to_owned();
-        let to_path = to_path.unwrap_or_default();
-        let from_path = from_path.unwrap_or_default();
-
+        let path = path.unwrap_or_else(|| vec![addr.into()]);
+        let path_end_cursor = path_end_cursor.unwrap_or(0);
         let relay_verification = MessageVerification {
             session: session_manager.session()?,
             sig: session_manager.sign(msg)?,
@@ -134,10 +141,51 @@ where
             tx_id,
             relay_verification,
             origin_verification,
-            to_path,
-            from_path,
             method,
+            path,
+            path_end_cursor,
+            next_hop,
+            destination,
         })
+    }
+
+    pub fn rewrap(
+        &self,
+        data: T,
+        session_manager: &SessionManager,
+        origin_verification_gen: OriginVerificationGen,
+    ) -> Result<Self> {
+        Self::new(
+            data,
+            session_manager,
+            origin_verification_gen,
+            self.method.clone(),
+            Some(self.path.clone()),
+            Some(self.path_end_cursor),
+            self.next_hop,
+            self.destination,
+        )
+    }
+
+    pub fn report(&self, data: T, session_manager: &SessionManager) -> Result<Self> {
+        if self.method != MessageRelayMethod::SEND {
+            return Err(Error::ReportNeedSend);
+        }
+
+        if self.path.len() < 2 {
+            return Err(Error::CannotInferNextHop);
+        }
+
+        Self::new(
+            data,
+            session_manager,
+            OriginVerificationGen::Origin,
+            MessageRelayMethod::REPORT,
+            Some(self.path.clone()),
+            Some(self.path_end_cursor),
+            self.path_prev(),
+            self.sender(),
+        )
     }
 
     pub fn is_expired(&self) -> bool {
@@ -217,7 +265,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ecc::SecretKey, transports::helper::TricklePayload};
+    use crate::ecc::SecretKey;
 
     #[derive(Deserialize, Serialize, PartialEq, Debug)]
     struct TestData {
@@ -229,6 +277,7 @@ mod tests {
 
     fn new_test_message() -> MessageRelay<TestData> {
         let key = SecretKey::random();
+        let destination = SecretKey::random().address().into();
         let session = SessionManager::new_with_seckey(&key).unwrap();
         let test_data = TestData {
             a: "hello".to_string(),
@@ -240,31 +289,35 @@ mod tests {
             test_data,
             &session,
             OriginVerificationGen::Origin,
-            None,
-            None,
-            None,
             MessageRelayMethod::SEND,
+            None,
+            None,
+            None,
+            destination,
         )
         .unwrap()
     }
 
     #[test]
     fn new_then_verify() {
-        let payload = new_test_message();
+        let mut payload = new_test_message();
         assert!(payload.verify());
 
         let key2 = SecretKey::random();
+        let did2 = key2.address().into();
         let session2 = SessionManager::new_with_seckey(&key2).unwrap();
-        let relaied_payload = MessageRelay::new(
-            payload.data,
-            &session2,
-            OriginVerificationGen::Stick(payload.origin_verification),
-            None,
-            None,
-            None,
-            MessageRelayMethod::SEND,
-        )
-        .unwrap();
+
+        payload.next_hop = Some(did2);
+        payload.relay(did2, None).unwrap();
+
+        let relaied_payload = payload
+            .rewrap(
+                payload.data,
+                &session2,
+                OriginVerificationGen::Stick(payload.origin_verification),
+            )
+            .unwrap();
+
         assert!(relaied_payload.verify());
     }
 
@@ -286,31 +339,5 @@ mod tests {
         let ungzip_encoded_payload = payload.to_json_vec().unwrap().encode().unwrap();
         let payload2: MessageRelay<TestData> = ungzip_encoded_payload.decode().unwrap();
         assert_eq!(payload, payload2);
-    }
-
-    #[test]
-    fn test_message_relay_verify() {
-        let key = SecretKey::random();
-        let (auth, s_key) =
-            SessionManager::gen_unsign_info(key.address(), None, Some(Signer::DEFAULT)).unwrap();
-        let sig = key.sign(&auth.to_string().unwrap()).to_vec();
-        let session = SessionManager::new(&sig, &auth, &s_key);
-
-        let test_data = TricklePayload {
-            sdp: "test_sdp".to_owned(),
-            candidates: vec![],
-        };
-        let payload = MessageRelay::new(
-            test_data,
-            &session,
-            OriginVerificationGen::Origin,
-            None,
-            None,
-            None,
-            MessageRelayMethod::SEND,
-        )
-        .unwrap();
-
-        assert!(payload.verify(), "payload verify failed");
     }
 }

--- a/rings-core/src/message/protocol.rs
+++ b/rings-core/src/message/protocol.rs
@@ -1,196 +1,120 @@
-use crate::dht::Did;
+#![warn(missing_docs)]
 
 use super::payload::MessageRelay;
 use super::payload::MessageRelayMethod;
-use super::types::Message;
+use crate::dht::Did;
+use crate::err::{Error, Result};
 
-// A -> B -> C
-// B handle_find_success relay with SEND contains
-// {
-//     from_path: [A]
-//     to_path: [B]
-// }
-// if find successor on B, then return relay with REPORT
-// then A get relay contains
-// {
-//     from_path: [B],
-//     to_path: [A]
-// }
-// otherwise, send to C with relay with SEND contains
-// {
-//    from_path: [A, B]
-//    to_path: [B, C]
-// }
-// if find successor on C, than return relay with REPORT
-// then B get relay contains
-// {
-//    from_path: [B, C]
-//    to_path: [A, B]
-// }
+/// MessageSessionRelayProtocol guide message passing on rings network by relay.
 pub trait MessageSessionRelayProtocol {
+    /// Check current did, update path and its end cursor, then infer next_hop.
+    fn relay(&mut self, current: Did, next_hop: Option<Did>) -> Result<()>;
+
+    /// A SEND message can change its destination.
+    /// Call with REPORT method will get an error imeediately.
+    fn reset_destination(&mut self, destination: Did) -> Result<()>;
+
+    /// Check if path and destination is valid.
+    /// It will be automatically called at relay started.
+    fn validate(&self) -> Result<()>;
+
+    /// Get sender of current message.
+    /// With SEND method, it will be the `origin()` of the message.
+    /// With REPORT method, it will be the last element of path.
     fn sender(&self) -> Did;
+
+    /// Get the original sender of current message.
+    /// Should always be the first element of path.
     fn origin(&self) -> Did;
-    fn has_next(&self) -> bool;
-    fn next(&self) -> Option<Did>;
-    fn target(&self) -> Did;
-    // add self to list
-    fn relay(&mut self, current: Did, next: Option<Did>);
-    fn find_prev(&self) -> Option<Did>;
-    fn push_prev(&mut self, current: Did, prev: Did);
-    fn next_hop(&mut self, current: Did, next: Did);
-    fn add_to_path(&mut self, node: Did);
-    fn add_from_path(&mut self, node: Did);
-    fn remove_to_path(&mut self) -> Option<Did>;
-    fn remove_from_path(&mut self) -> Option<Did>;
+
+    /// Get the previous element of the element pointed by path_end_cursor.
+    fn path_prev(&self) -> Option<Did>;
 }
 
-impl MessageSessionRelayProtocol for MessageRelay<Message> {
-    // record self to relay list
-    // for Send, push self to back of from_path
-    // From<A, B> - [Current] - To<C, D> =>
-    // From<A, B, Current>, To<C, D>
-    // for Report, push self to front of to_path
-    // From<A, B> - [Current] - To<C, D> =>
-    // From<A, B>, To<Current, C, D>
+impl<T> MessageSessionRelayProtocol for MessageRelay<T> {
+    fn relay(&mut self, current: Did, next_hop: Option<Did>) -> Result<()> {
+        self.validate()?;
 
-    fn relay(&mut self, current: Did, next: Option<Did>) {
+        // If self.next_hop is setted, it should be current
+        if self.next_hop.is_some() && self.next_hop.unwrap() != current {
+            return Err(Error::InvalidNextHop);
+        }
+
         match self.method {
             MessageRelayMethod::SEND => {
-                if let Some(id) = next {
-                    // if next hop is not in path plan, push it to `to_path`
-                    if self.to_path.front() != Some(&id) {
-                        self.to_path.push_front(id);
-                    }
-                }
-                // always reocrd current; even it's a loop
-                self.to_path.pop_back().unwrap();
-                self.from_path.push_back(current);
+                self.path.push(current);
+                self.next_hop = next_hop;
+                Ok(())
             }
+
             MessageRelayMethod::REPORT => {
-                // should always has a prev
-                let prev = self.from_path.pop_back().unwrap();
-                self.to_path.push_front(prev);
+                // The final hop
+                if self.next_hop == Some(self.destination) {
+                    self.path_end_cursor = self.path.len() - 1;
+                    self.next_hop = None;
+                    return Ok(());
+                }
+
+                let pos = self
+                    .path
+                    .iter()
+                    .rev()
+                    .skip(self.path_end_cursor)
+                    .position(|&x| x == current);
+
+                if let (None, None) = (pos, next_hop) {
+                    return Err(Error::CannotInferNextHop);
+                }
+
+                if let Some(pos) = pos {
+                    self.path_end_cursor += pos;
+                }
+
+                // `self.path_prev()` should never return None here, because we have handled final hop
+                self.next_hop = next_hop.or_else(|| self.path_prev());
+
+                Ok(())
             }
         }
     }
 
-    // for Send, the last ele of from_path is Sender
-    // for Report, the first ele of to_path is Sender
-    // A recived Relay should *ALWAYS* has it's sender
+    fn reset_destination(&mut self, destination: Did) -> Result<()> {
+        if self.method == MessageRelayMethod::SEND {
+            self.destination = destination;
+            Ok(())
+        } else {
+            Err(Error::ResetDestinationNeedSend)
+        }
+    }
+
+    fn validate(&self) -> Result<()> {
+        // Adjacent elements in self.path cannot be equal
+        if self.path.windows(2).any(|w| w[0] == w[1]) {
+            return Err(Error::InvalidRelayPath);
+        }
+
+        // The destination of report message should always be the first element of path
+        if self.method == MessageRelayMethod::REPORT && self.path[0] != self.destination {
+            return Err(Error::InvalidRelayDestination);
+        }
+
+        Ok(())
+    }
+
+    fn origin(&self) -> Did {
+        *self.path.first().unwrap()
+    }
+
     fn sender(&self) -> Did {
         match self.method {
-            MessageRelayMethod::SEND => *self.from_path.back().unwrap(),
-            MessageRelayMethod::REPORT => *self.to_path.front().unwrap(),
+            MessageRelayMethod::SEND => self.origin(),
+            MessageRelayMethod::REPORT => *self.path.last().unwrap(),
         }
     }
 
-    // Origin is where the msg is send_from
-    // for Send it's the first ele of from_path
-    // for Report, it's the last ele of to_path
-    // A recived Relay should *ALWAYS* has it's origin
-    fn origin(&self) -> Did {
-        match self.method {
-            MessageRelayMethod::SEND => *self.from_path.front().unwrap(),
-            MessageRelayMethod::REPORT => *self.to_path.front().unwrap(),
-        }
-    }
-
-    // A recived Relay should *ALWAYS* has it's target
-    fn target(&self) -> Did {
-        match self.method {
-            MessageRelayMethod::SEND => *self.to_path.back().unwrap(),
-            MessageRelayMethod::REPORT => *self.from_path.back().unwrap(),
-        }
-    }
-
-    fn has_next(&self) -> bool {
-        match self.method {
-            MessageRelayMethod::SEND => !self.to_path.is_empty(),
-            MessageRelayMethod::REPORT => !self.from_path.is_empty(),
-        }
-    }
-
-    // for send, the next hop is the first ele of to_path
-    // From<[A, B]> [Current] To<[D, E]> -> D
-    // for report, the next hop is the back ele of from_path
-    // From<[A, B]> [Current] To<[D, E]> -> D
-
-    fn next(&self) -> Option<Did> {
-        match self.method {
-            MessageRelayMethod::SEND => self.to_path.front().copied(),
-            MessageRelayMethod::REPORT => self.from_path.back().copied(),
-        }
-    }
-
-    #[inline]
-    fn find_prev(&self) -> Option<Did> {
-        match self.method {
-            MessageRelayMethod::SEND => {
-                if !self.from_path.is_empty() {
-                    self.from_path.back().cloned()
-                } else {
-                    None
-                }
-            }
-            MessageRelayMethod::REPORT => {
-                if !self.to_path.is_empty() {
-                    self.to_path.back().cloned()
-                } else {
-                    None
-                }
-            }
-        }
-    }
-
-    #[inline]
-    fn push_prev(&mut self, _current: Did, prev: Did) {
-        match self.method {
-            MessageRelayMethod::SEND => {
-                self.from_path.push_back(prev);
-            }
-            MessageRelayMethod::REPORT => {
-                self.to_path.pop_back();
-                self.from_path.push_back(prev);
-            }
-        }
-    }
-
-    #[inline]
-    fn next_hop(&mut self, current: Did, next: Did) {
-        match self.method {
-            MessageRelayMethod::SEND => {
-                self.to_path.push_back(next);
-                self.from_path.push_back(current);
-            }
-            MessageRelayMethod::REPORT => unimplemented!(),
-        };
-    }
-
-    #[inline]
-    fn add_to_path(&mut self, node: Did) {
-        self.to_path.push_back(node);
-    }
-
-    #[inline]
-    fn add_from_path(&mut self, node: Did) {
-        self.from_path.push_back(node);
-    }
-
-    #[inline]
-    fn remove_to_path(&mut self) -> Option<Did> {
-        if !self.to_path.is_empty() {
-            self.to_path.pop_back()
-        } else {
-            None
-        }
-    }
-
-    #[inline]
-    fn remove_from_path(&mut self) -> Option<Did> {
-        if !self.from_path.is_empty() {
-            self.from_path.pop_back()
-        } else {
-            None
-        }
+    fn path_prev(&self) -> Option<Did> {
+        self.path
+            .get(self.path.len() - 1 - self.path_end_cursor)
+            .copied()
     }
 }

--- a/rings-core/src/swarm.rs
+++ b/rings-core/src/swarm.rs
@@ -99,10 +99,11 @@ impl Swarm {
                         Message::JoinDHT(message::JoinDHT { id: address.into() }),
                         &self.session_manager,
                         OriginVerificationGen::Origin,
-                        None,
-                        Some(vec![self.address().into()].into()),
-                        Some(vec![self.address().into()].into()),
                         MessageRelayMethod::SEND,
+                        None,
+                        None,
+                        None,
+                        self.address().into(),
                     )?;
                     Ok(Some(payload))
                 }
@@ -114,10 +115,11 @@ impl Swarm {
                         Message::LeaveDHT(message::LeaveDHT { id: address.into() }),
                         &self.session_manager,
                         OriginVerificationGen::Origin,
-                        None,
-                        Some(vec![self.address().into()].into()),
-                        Some(vec![self.address().into()].into()),
                         MessageRelayMethod::SEND,
+                        None,
+                        None,
+                        None,
+                        self.address().into(),
                     )?;
                     Ok(Some(payload))
                 } else {

--- a/rings-core/src/transports/default/transport.rs
+++ b/rings-core/src/transports/default/transport.rs
@@ -414,10 +414,11 @@ impl IceTrickleScheme<Event, AcChannel<Event>> for DefaultTransport {
             data,
             session_manager,
             OriginVerificationGen::Origin,
-            None,
-            None,
-            None,
             MessageRelayMethod::SEND,
+            None,
+            None,
+            None,
+            session_manager.authorizer()?.to_owned().into(), // This is a fake destination
         )?;
         Ok(resp.gzip(9)?.encode()?)
     }

--- a/rings-core/src/transports/wasm/transport.rs
+++ b/rings-core/src/transports/wasm/transport.rs
@@ -447,7 +447,6 @@ impl IceTrickleScheme<Event, CbChannel<Event>> for WasmTransport {
             None,
             None,
             session_manager.authorizer()?.to_owned().into(), // This is a fake destination
-
         )?;
         Ok(resp.gzip(9)?.encode()?)
     }

--- a/rings-core/src/transports/wasm/transport.rs
+++ b/rings-core/src/transports/wasm/transport.rs
@@ -442,10 +442,12 @@ impl IceTrickleScheme<Event, CbChannel<Event>> for WasmTransport {
             data,
             session_manager,
             OriginVerificationGen::Origin,
-            None,
-            None,
-            None,
             MessageRelayMethod::SEND,
+            None,
+            None,
+            None,
+            session_manager.authorizer()?.to_owned().into(), // This is a fake destination
+
         )?;
         Ok(resp.gzip(9)?.encode()?)
     }

--- a/rings-core/tests/default/test_message_handler.rs
+++ b/rings-core/tests/default/test_message_handler.rs
@@ -8,8 +8,8 @@ pub mod test {
     use rings_core::err::Result;
     use rings_core::message;
     use rings_core::message::Encoder;
+    use rings_core::message::Message;
     use rings_core::message::MessageHandler;
-    use rings_core::message::{Message, MessageRelayMethod, OriginVerificationGen};
     use rings_core::session::SessionManager;
     use rings_core::storage::Storage;
     use rings_core::swarm::Swarm;
@@ -271,12 +271,9 @@ pub mod test {
                 // dht1 send msg to dht2 ask for connecting dht3
                 handler1
                     .send_message(
-                        &swarm2.address(),
-                        None,
-                        None,
-                        MessageRelayMethod::SEND,
-                        OriginVerificationGen::Origin,
-                        connect_msg.clone(),
+                        &swarm2.address().into(),
+                        &swarm3.address().into(),
+                        connect_msg,
                     )
                     .await
                     .unwrap();
@@ -340,11 +337,8 @@ pub mod test {
                 );
                 handler1
                     .send_message(
-                        &swarm2.address(),
-                        None,
-                        None,
-                        MessageRelayMethod::SEND,
-                        OriginVerificationGen::Origin,
+                        &swarm2.address().into(),
+                        &swarm2.address().into(),
                         Message::NotifyPredecessorSend(message::NotifyPredecessorSend {
                             id: key1.address().into(),
                         }),
@@ -403,11 +397,8 @@ pub mod test {
                 );
                 handler1
                     .send_message(
-                        &swarm2.address(),
-                        None,
-                        None,
-                        MessageRelayMethod::SEND,
-                        OriginVerificationGen::Origin,
+                        &swarm2.address().into(),
+                        &swarm2.address().into(),
                         Message::NotifyPredecessorSend(message::NotifyPredecessorSend {
                             id: swarm1.address().into(),
                         }),
@@ -425,11 +416,8 @@ pub mod test {
                 );
                 handler2
                     .send_message(
-                        &swarm1.address(),
-                        None,
-                        None,
-                        MessageRelayMethod::SEND,
-                        OriginVerificationGen::Origin,
+                        &swarm1.address().into(),
+                        &swarm1.address().into(),
                         Message::FindSuccessorSend(message::FindSuccessorSend {
                             id: swarm2.address().into(),
                             for_fix: false,
@@ -500,11 +488,8 @@ pub mod test {
                 );
                 handler1
                     .send_message(
-                        &swarm2.address(),
-                        None,
-                        None,
-                        MessageRelayMethod::SEND,
-                        OriginVerificationGen::Origin,
+                        &swarm2.address().into(),
+                        &swarm2.address().into(),
                         Message::NotifyPredecessorSend(message::NotifyPredecessorSend {
                             id: swarm1.address().into(),
                         }),
@@ -521,11 +506,8 @@ pub mod test {
                 );
                 handler2
                     .send_message(
-                        &swarm1.address(),
-                        None,
-                        None,
-                        MessageRelayMethod::SEND,
-                        OriginVerificationGen::Origin,
+                        &swarm1.address().into(),
+                        &swarm1.address().into(),
                         Message::FindSuccessorSend(message::FindSuccessorSend {
                             id: swarm2.address().into(),
                             for_fix: false,
@@ -595,11 +577,8 @@ pub mod test {
                  );
                  handler1
                      .send_message(
-                         &swarm2.address(),
-                         None,
-                         None,
-                         MessageRelayMethod::SEND,
-                         OriginVerificationGen::Origin,
+                         &swarm2.address().into(),
+                         &swarm2.address().into(),
                          Message::NotifyPredecessorSend(message::NotifyPredecessorSend {
                              id: swarm1.address().into(),
                          }),
@@ -616,11 +595,8 @@ pub mod test {
                  // the vid is hash of string
                  let vnode: VirtualNode = encoded_message.try_into().unwrap();
                  handler1.send_message(
-                     &swarm2.address(),
-                     None,
-                     None,
-                     MessageRelayMethod::SEND,
-                     OriginVerificationGen::Origin,
+                     &swarm2.address().into(),
+                     &swarm2.address().into(),
                      Message::StoreVNode(message::StoreVNode {
                          sender_id: swarm1.address().into(),
                          data: vec![vnode.clone()]

--- a/rings-core/tests/wasm/test_wasm_transport.rs
+++ b/rings-core/tests/wasm/test_wasm_transport.rs
@@ -193,7 +193,5 @@ pub mod test {
 
         node1.listen_once().await;
         node2.listen_once().await;
-        // assert_eq!(&ev_1.from_path.clone(), &vec![key1.address().into()]);
-        // assert_eq!(&ev_1.to_path.clone(), &vec![key1.address().into()]);
     }
 }

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -290,10 +290,10 @@ impl Client {
     }
 
     /// send custome message to peer.
-    pub fn send_message(&self, address: String, msg: String) -> Promise {
+    pub fn send_message(&self, next_hop: String, destination: String, msg: String) -> Promise {
         let p = self.processor.clone();
         future_to_promise(async move {
-            p.send_message(address.as_str(), msg)
+            p.send_message(next_hop.as_str(), destination.as_str(), msg)
                 .await
                 .map_err(JsError::from)?;
             Ok(JsValue::from_bool(true))

--- a/src/jsonrpc/server.rs
+++ b/src/jsonrpc/server.rs
@@ -97,8 +97,13 @@ async fn close_connection(params: Params, processor: Processor) -> Result<Value>
 
 async fn send_message(params: Params, processor: Processor) -> Result<Value> {
     let params: serde_json::Map<String, Value> = params.parse()?;
-    let address = params
-        .get("address")
+    let next_hop = params
+        .get("next_hop")
+        .ok_or_else(|| Error::new(ErrorCode::InvalidParams))?
+        .as_str()
+        .ok_or_else(|| Error::new(ErrorCode::InvalidParams))?;
+    let destination = params
+        .get("destination")
         .ok_or_else(|| Error::new(ErrorCode::InvalidParams))?
         .as_str()
         .ok_or_else(|| Error::new(ErrorCode::InvalidParams))?;
@@ -108,6 +113,6 @@ async fn send_message(params: Params, processor: Processor) -> Result<Value> {
         .as_str()
         .ok_or_else(|| Error::new(ErrorCode::InvalidParams))?;
 
-    processor.send_message(address, text).await?;
+    processor.send_message(next_hop, destination, text).await?;
     Ok(serde_json::json!({}))
 }

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -290,15 +290,21 @@ impl Processor {
     }
 
     /// Send custom message to an address.
-    pub async fn send_message<T>(&self, address: &str, msg: T) -> Result<()>
+    pub async fn send_message<T>(&self, next_hop: &str, destination: &str, msg: T) -> Result<()>
     where
         T: ToString,
     {
-        log::info!("send_message, to: {}, text: {}", address, msg.to_string());
-        let address = Address::from_str(address).map_err(|_| Error::InvalidAddress)?;
+        log::info!(
+            "send_message, to: {}, destination: {}, text: {}",
+            next_hop,
+            destination,
+            msg.to_string()
+        );
+        let next_hop = Address::from_str(next_hop).map_err(|_| Error::InvalidAddress)?;
+        let destination = Address::from_str(destination).map_err(|_| Error::InvalidAddress)?;
         let msg = Message::custom(msg.to_string().as_str(), &None).map_err(Error::SendMessage)?;
         self.msg_handler
-            .send_message_default(&address, msg)
+            .send_message(&next_hop.into(), &destination.into(), msg)
             .await
             .map_err(Error::SendMessage)?;
         Ok(())


### PR DESCRIPTION
The new relay fields:
```rust
{
    // A push only stack. Record routes when sending message.
    path: Vec<Did>,

    // Move this cursor to flag the top of stack when reporting.
    path_end_cursor: usize,

    // The next node to handle the message. Current handler will pick transport by this field.
    // When and only when located at the end of the message propagation, the next_hop is none.
    next_hop: Some<Did>,

    // The final destination of the message. May be customized when sending. Cannot change when reporting.
    // It may help handler to find out next_hop in some situations.
    destination: Did,
}
```

To **send** a message, you must provide both next_hop and destination.
```rust
    pub async fn send_message(
        &self,
        next_hop: &Did,
        destination: &Did,
        msg: Message,
    ) -> Result<()> {...}
```

To **send** or **report** a message, you can also use send_relay_message. Usually, use in relay processing.
```rust
    pub async fn send_relay_message(&self, msg: MessageRelay<Message>) -> Result<()> {...}
```