### PR TITLE
Split protocols, add two traits PayloadSender and HandleMsg

### DIFF
--- a/bin/daemon.rs
+++ b/bin/daemon.rs
@@ -8,7 +8,7 @@ use rings_node::{
         async_trait,
         dht::{PeerRing, Stabilization, TStabilize},
         ecc::SecretKey,
-        message::{self, CustomMessage, MaybeEncrypted, Message, MessageHandler, MessageRelay},
+        message::{self, CustomMessage, MaybeEncrypted, Message, MessageHandler, MessagePayload},
         prelude::url,
         session::SessionManager,
         swarm::Swarm,
@@ -200,7 +200,7 @@ impl message::MessageCallback for MessageCallback {
     async fn custom_message(
         &self,
         handler: &MessageHandler,
-        _relay: &MessageRelay<Message>,
+        _ctx: &MessagePayload<Message>,
         msg: &MaybeEncrypted<CustomMessage>,
     ) {
         if let Ok(msg) = handler.decrypt_msg(msg) {
@@ -213,7 +213,7 @@ impl message::MessageCallback for MessageCallback {
             log::info!("[MESSAGE] custom_message: {:?}", msg);
         }
     }
-    async fn builtin_message(&self, _handler: &MessageHandler, _relay: &MessageRelay<Message>) {}
+    async fn builtin_message(&self, _handler: &MessageHandler, _ctx: &MessagePayload<Message>) {}
 }
 
 fn run_daemon(args: &RunArgs) -> AnyhowResult<()> {

--- a/rings-core/src/dht/stabilization.rs
+++ b/rings-core/src/dht/stabilization.rs
@@ -1,9 +1,6 @@
 use crate::dht::{ChordStablize, PeerRing, PeerRingAction, PeerRingRemoteAction};
 use crate::err::Result;
-use crate::message::{
-    FindSuccessorSend, Message, MessageRelay, MessageRelayMethod, NotifyPredecessorSend,
-    OriginVerificationGen,
-};
+use crate::message::{FindSuccessorSend, Message, MessagePayload, NotifyPredecessorSend};
 use crate::swarm::Swarm;
 
 use async_trait::async_trait;
@@ -38,14 +35,9 @@ impl Stabilization {
 
     async fn notify_predecessor(&self) -> Result<()> {
         let chord = self.chord.lock().await;
-        let message = MessageRelay::new(
+        let message = MessagePayload::new_direct(
             Message::NotifyPredecessorSend(NotifyPredecessorSend { id: chord.id }),
             &self.swarm.session_manager,
-            OriginVerificationGen::Origin,
-            MessageRelayMethod::SEND,
-            None,
-            None,
-            None,
             self.swarm.address().into(),
         )?;
         if chord.id != chord.successor.min() {
@@ -70,17 +62,12 @@ impl Stabilization {
                     next,
                     PeerRingRemoteAction::FindSuccessorForFix(current),
                 ) => {
-                    let message = MessageRelay::new(
+                    let message = MessagePayload::new_direct(
                         Message::FindSuccessorSend(FindSuccessorSend {
                             id: current,
                             for_fix: true,
                         }),
                         &self.swarm.session_manager,
-                        OriginVerificationGen::Origin,
-                        MessageRelayMethod::SEND,
-                        None,
-                        None,
-                        None,
                         self.swarm.address().into(),
                     )?;
                     self.swarm.send_message(&next.into(), message).await

--- a/rings-core/src/dht/vnode.rs
+++ b/rings-core/src/dht/vnode.rs
@@ -4,7 +4,7 @@ use crate::ecc::HashStr;
 use crate::err::{Error, Result};
 use crate::message::Encoded;
 use crate::message::Encoder;
-use crate::message::MessageRelay;
+use crate::message::MessagePayload;
 use num_bigint::BigUint;
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
@@ -44,12 +44,12 @@ impl VirtualNode {
     }
 }
 
-impl<T> TryFrom<MessageRelay<T>> for VirtualNode
+impl<T> TryFrom<MessagePayload<T>> for VirtualNode
 where
     T: Serialize + DeserializeOwned,
 {
     type Error = Error;
-    fn try_from(msg: MessageRelay<T>) -> Result<Self> {
+    fn try_from(msg: MessagePayload<T>) -> Result<Self> {
         let address = BigUint::from(Did::from(msg.addr)) + BigUint::from(1u16);
         let data = msg.encode()?;
         Ok(Self {

--- a/rings-core/src/lib.rs
+++ b/rings-core/src/lib.rs
@@ -22,7 +22,7 @@
 //! 3. E2e encrypt
 //! - After joining Ring, should encrypt all direct messages with the ElGamal algorithm.
 //!
-//! # MessageRelay
+//! # MessagePayload
 //!
 //! MSRP over WebRTC Data Channel is Published in Jan/2021, which is based on The Message Session Relay Protocol and its extension.
 //!

--- a/rings-core/src/message/handlers/connection.rs
+++ b/rings-core/src/message/handlers/connection.rs
@@ -372,11 +372,11 @@ mod test {
 
         // JoinDHT
         let ev_1 = node1.listen_once().await.unwrap();
-        assert_eq!(ev_1.method, RelayMethod::SEND);
-        assert_eq!(ev_1.path, vec![did1]);
-        assert_eq!(ev_1.path_end_cursor, 0);
-        assert_eq!(ev_1.next_hop, None);
-        assert_eq!(ev_1.destination, did1);
+        assert_eq!(ev_1.relay.method, RelayMethod::SEND);
+        assert_eq!(ev_1.relay.path, vec![did1]);
+        assert_eq!(ev_1.relay.path_end_cursor, 0);
+        assert_eq!(ev_1.relay.next_hop, Some(did1));
+        assert_eq!(ev_1.relay.destination, did1);
         if let Message::JoinDHT(x) = ev_1.data {
             assert_eq!(x.id, did2);
         } else {
@@ -387,11 +387,11 @@ mod test {
         assert_eq!(&ev_1.addr, &key1.address());
 
         let ev_2 = node2.listen_once().await.unwrap();
-        assert_eq!(ev_2.method, RelayMethod::SEND);
-        assert_eq!(ev_2.path, vec![did2]);
-        assert_eq!(ev_2.path_end_cursor, 0);
-        assert_eq!(ev_2.next_hop, None);
-        assert_eq!(ev_2.destination, did2);
+        assert_eq!(ev_2.relay.method, RelayMethod::SEND);
+        assert_eq!(ev_2.relay.path, vec![did2]);
+        assert_eq!(ev_2.relay.path_end_cursor, 0);
+        assert_eq!(ev_2.relay.next_hop, Some(did2));
+        assert_eq!(ev_2.relay.destination, did2);
         if let Message::JoinDHT(x) = ev_2.data {
             assert_eq!(x.id, did1);
         } else {
@@ -404,11 +404,11 @@ mod test {
         let ev_1 = node1.listen_once().await.unwrap();
         // msg is send from key2
         assert_eq!(ev_1.addr, key2.address());
-        assert_eq!(ev_1.method, RelayMethod::SEND);
-        assert_eq!(ev_1.path, vec![did2]);
-        assert_eq!(ev_1.path_end_cursor, 0);
-        assert_eq!(ev_1.next_hop, Some(did1));
-        assert_eq!(ev_1.destination, did1);
+        assert_eq!(ev_1.relay.method, RelayMethod::SEND);
+        assert_eq!(ev_1.relay.path, vec![did2]);
+        assert_eq!(ev_1.relay.path_end_cursor, 0);
+        assert_eq!(ev_1.relay.next_hop, Some(did1));
+        assert_eq!(ev_1.relay.destination, did1);
         if let Message::FindSuccessorSend(x) = ev_1.data {
             assert_eq!(x.id, did2);
             assert!(!x.for_fix);
@@ -418,11 +418,11 @@ mod test {
 
         let ev_2 = node2.listen_once().await.unwrap();
         assert_eq!(ev_2.addr, key1.address());
-        assert_eq!(ev_2.method, RelayMethod::SEND);
-        assert_eq!(ev_2.path, vec![did1]);
-        assert_eq!(ev_2.path_end_cursor, 0);
-        assert_eq!(ev_2.next_hop, Some(did2));
-        assert_eq!(ev_2.destination, did2);
+        assert_eq!(ev_2.relay.method, RelayMethod::SEND);
+        assert_eq!(ev_2.relay.path, vec![did1]);
+        assert_eq!(ev_2.relay.path_end_cursor, 0);
+        assert_eq!(ev_2.relay.next_hop, Some(did2));
+        assert_eq!(ev_2.relay.destination, did2);
         if let Message::FindSuccessorSend(x) = ev_2.data {
             assert_eq!(x.id, did1);
             assert!(!x.for_fix);
@@ -433,11 +433,11 @@ mod test {
         // node2 response self as node1's successor
         let ev_1 = node1.listen_once().await.unwrap();
         assert_eq!(ev_1.addr, key2.address());
-        assert_eq!(ev_1.method, RelayMethod::REPORT);
-        assert_eq!(ev_1.path, vec![did1, did2]);
-        assert_eq!(ev_1.path_end_cursor, 0);
-        assert_eq!(ev_1.next_hop, Some(did1));
-        assert_eq!(ev_1.destination, did1);
+        assert_eq!(ev_1.relay.method, RelayMethod::REPORT);
+        assert_eq!(ev_1.relay.path, vec![did1, did2]);
+        assert_eq!(ev_1.relay.path_end_cursor, 0);
+        assert_eq!(ev_1.relay.next_hop, Some(did1));
+        assert_eq!(ev_1.relay.destination, did1);
         if let Message::FindSuccessorReport(x) = ev_1.data {
             // for node2 there is no did is more closer to key1, so it response key1
             // and dht1 wont update
@@ -451,11 +451,11 @@ mod test {
         // key1 response self as key2's successor
         let ev_2 = node2.listen_once().await.unwrap();
         assert_eq!(ev_2.addr, key1.address());
-        assert_eq!(ev_2.method, RelayMethod::REPORT);
-        assert_eq!(ev_2.path, vec![did2, did1]);
-        assert_eq!(ev_2.path_end_cursor, 0);
-        assert_eq!(ev_2.next_hop, Some(did2));
-        assert_eq!(ev_2.destination, did2);
+        assert_eq!(ev_2.relay.method, RelayMethod::REPORT);
+        assert_eq!(ev_2.relay.path, vec![did2, did1]);
+        assert_eq!(ev_2.relay.path_end_cursor, 0);
+        assert_eq!(ev_2.relay.next_hop, Some(did2));
+        assert_eq!(ev_2.relay.destination, did2);
         if let Message::FindSuccessorReport(x) = ev_2.data {
             // for key1 there is no did is more closer to key1, so it response key1
             // and dht2 wont update
@@ -505,11 +505,11 @@ mod test {
 
         let ev_3 = node3.listen_once().await.unwrap();
         assert_eq!(ev_3.addr, key3.address());
-        assert_eq!(ev_3.method, RelayMethod::SEND);
-        assert_eq!(ev_3.path, vec![did3]);
-        assert_eq!(ev_3.path_end_cursor, 0);
-        assert_eq!(ev_3.next_hop, None);
-        assert_eq!(ev_3.destination, did3);
+        assert_eq!(ev_3.relay.method, RelayMethod::SEND);
+        assert_eq!(ev_3.relay.path, vec![did3]);
+        assert_eq!(ev_3.relay.path_end_cursor, 0);
+        assert_eq!(ev_3.relay.next_hop, Some(did3));
+        assert_eq!(ev_3.relay.destination, did3);
         if let Message::JoinDHT(x) = ev_3.data {
             assert_eq!(x.id, did2);
         } else {
@@ -518,11 +518,11 @@ mod test {
 
         let ev_2 = node2.listen_once().await.unwrap();
         assert_eq!(ev_2.addr, key2.address());
-        assert_eq!(ev_2.method, RelayMethod::SEND);
-        assert_eq!(ev_2.path, vec![did2]);
-        assert_eq!(ev_2.path_end_cursor, 0);
-        assert_eq!(ev_2.next_hop, None);
-        assert_eq!(ev_2.destination, did2);
+        assert_eq!(ev_2.relay.method, RelayMethod::SEND);
+        assert_eq!(ev_2.relay.path, vec![did2]);
+        assert_eq!(ev_2.relay.path_end_cursor, 0);
+        assert_eq!(ev_2.relay.next_hop, Some(did2));
+        assert_eq!(ev_2.relay.destination, did2);
         if let Message::JoinDHT(x) = ev_2.data {
             assert_eq!(x.id, did3);
         } else {
@@ -532,11 +532,11 @@ mod test {
         let ev_3 = node3.listen_once().await.unwrap();
         // msg is send from node2
         assert_eq!(ev_3.addr, key2.address());
-        assert_eq!(ev_3.method, RelayMethod::SEND);
-        assert_eq!(ev_3.path, vec![did2]);
-        assert_eq!(ev_3.path_end_cursor, 0);
-        assert_eq!(ev_3.next_hop, Some(did3));
-        assert_eq!(ev_3.destination, did3);
+        assert_eq!(ev_3.relay.method, RelayMethod::SEND);
+        assert_eq!(ev_3.relay.path, vec![did2]);
+        assert_eq!(ev_3.relay.path_end_cursor, 0);
+        assert_eq!(ev_3.relay.next_hop, Some(did3));
+        assert_eq!(ev_3.relay.destination, did3);
         if let Message::FindSuccessorSend(x) = ev_3.data {
             assert_eq!(x.id, did2);
             assert!(!x.for_fix);
@@ -546,11 +546,11 @@ mod test {
 
         let ev_2 = node2.listen_once().await.unwrap();
         assert_eq!(ev_2.addr, key3.address());
-        assert_eq!(ev_2.method, RelayMethod::SEND);
-        assert_eq!(ev_2.path, vec![did3]);
-        assert_eq!(ev_2.path_end_cursor, 0);
-        assert_eq!(ev_2.next_hop, Some(did2));
-        assert_eq!(ev_2.destination, did2);
+        assert_eq!(ev_2.relay.method, RelayMethod::SEND);
+        assert_eq!(ev_2.relay.path, vec![did3]);
+        assert_eq!(ev_2.relay.path_end_cursor, 0);
+        assert_eq!(ev_2.relay.next_hop, Some(did2));
+        assert_eq!(ev_2.relay.destination, did2);
         if let Message::FindSuccessorSend(x) = ev_2.data {
             assert_eq!(x.id, did3);
             assert!(!x.for_fix);
@@ -561,11 +561,11 @@ mod test {
         // node2 response self as node1's successor
         let ev_3 = node3.listen_once().await.unwrap();
         assert_eq!(ev_3.addr, key2.address());
-        assert_eq!(ev_3.method, RelayMethod::REPORT);
-        assert_eq!(ev_3.path, vec![did3, did2]);
-        assert_eq!(ev_3.path_end_cursor, 0);
-        assert_eq!(ev_3.next_hop, Some(did3));
-        assert_eq!(ev_3.destination, did3);
+        assert_eq!(ev_3.relay.method, RelayMethod::REPORT);
+        assert_eq!(ev_3.relay.path, vec![did3, did2]);
+        assert_eq!(ev_3.relay.path_end_cursor, 0);
+        assert_eq!(ev_3.relay.next_hop, Some(did3));
+        assert_eq!(ev_3.relay.destination, did3);
         if let Message::FindSuccessorReport(x) = ev_3.data {
             // for node2 there is no did is more closer to key3, so it response key3
             // and dht3 wont update
@@ -579,11 +579,11 @@ mod test {
         // key3 response self as key2's successor
         let ev_2 = node2.listen_once().await.unwrap();
         assert_eq!(ev_2.addr, key3.address());
-        assert_eq!(ev_2.method, RelayMethod::REPORT);
-        assert_eq!(ev_2.path, vec![did2, did3]);
-        assert_eq!(ev_2.path_end_cursor, 0);
-        assert_eq!(ev_2.next_hop, Some(did2));
-        assert_eq!(ev_2.destination, did2);
+        assert_eq!(ev_2.relay.method, RelayMethod::REPORT);
+        assert_eq!(ev_2.relay.path, vec![did2, did3]);
+        assert_eq!(ev_2.relay.path_end_cursor, 0);
+        assert_eq!(ev_2.relay.next_hop, Some(did2));
+        assert_eq!(ev_2.relay.destination, did2);
         if let Message::FindSuccessorReport(x) = ev_2.data {
             // for key3 there is no did is more closer to key3, so it response key3
             // and dht2 wont update
@@ -606,11 +606,11 @@ mod test {
 
         // msg is send from node 1 to node 2
         assert_eq!(ev2.addr, key1.address());
-        assert_eq!(ev2.method, RelayMethod::SEND);
-        assert_eq!(ev2.path, vec![did1]);
-        assert_eq!(ev2.path_end_cursor, 0);
-        assert_eq!(ev2.next_hop, Some(did2));
-        assert_eq!(ev2.destination, did3);
+        assert_eq!(ev2.relay.method, RelayMethod::SEND);
+        assert_eq!(ev2.relay.path, vec![did1]);
+        assert_eq!(ev2.relay.path_end_cursor, 0);
+        assert_eq!(ev2.relay.next_hop, Some(did2));
+        assert_eq!(ev2.relay.destination, did3);
 
         if let Message::ConnectNodeSend(x) = ev2.data {
             assert_eq!(x.target_id, did3);
@@ -630,11 +630,11 @@ mod test {
         );
 
         assert_eq!(ev3.addr, key2.address());
-        assert_eq!(ev3.method, RelayMethod::SEND);
-        assert_eq!(ev3.path, vec![did1, did2]);
-        assert_eq!(ev3.path_end_cursor, 0);
-        assert_eq!(ev3.next_hop, Some(did3));
-        assert_eq!(ev3.destination, did3);
+        assert_eq!(ev3.relay.method, RelayMethod::SEND);
+        assert_eq!(ev3.relay.path, vec![did1, did2]);
+        assert_eq!(ev3.relay.path_end_cursor, 0);
+        assert_eq!(ev3.relay.next_hop, Some(did3));
+        assert_eq!(ev3.relay.destination, did3);
         if let Message::ConnectNodeSend(x) = ev3.data {
             assert_eq!(x.target_id, did3);
             assert_eq!(x.sender_id, did1);
@@ -645,11 +645,11 @@ mod test {
         let ev2 = node2.listen_once().await.unwrap();
         // node3 send report to node2
         assert_eq!(ev2.addr, key3.address());
-        assert_eq!(ev2.method, RelayMethod::REPORT);
-        assert_eq!(ev2.path, vec![did1, did2, did3]);
-        assert_eq!(ev2.path_end_cursor, 0);
-        assert_eq!(ev2.next_hop, Some(did2));
-        assert_eq!(ev2.destination, did1);
+        assert_eq!(ev2.relay.method, RelayMethod::REPORT);
+        assert_eq!(ev2.relay.path, vec![did1, did2, did3]);
+        assert_eq!(ev2.relay.path_end_cursor, 0);
+        assert_eq!(ev2.relay.next_hop, Some(did2));
+        assert_eq!(ev2.relay.destination, did1);
         if let Message::ConnectNodeReport(x) = ev2.data {
             assert_eq!(x.answer_id, did3);
         } else {
@@ -658,11 +658,11 @@ mod test {
         // node 2 send report to node1
         let ev1 = node1.listen_once().await.unwrap();
         assert_eq!(ev1.addr, key2.address());
-        assert_eq!(ev1.method, RelayMethod::REPORT);
-        assert_eq!(ev1.path, vec![did1, did2, did3]);
-        assert_eq!(ev1.path_end_cursor, 1);
-        assert_eq!(ev1.next_hop, Some(did1));
-        assert_eq!(ev1.destination, did1);
+        assert_eq!(ev1.relay.method, RelayMethod::REPORT);
+        assert_eq!(ev1.relay.path, vec![did1, did2, did3]);
+        assert_eq!(ev1.relay.path_end_cursor, 1);
+        assert_eq!(ev1.relay.next_hop, Some(did1));
+        assert_eq!(ev1.relay.destination, did1);
         if let Message::ConnectNodeReport(x) = ev1.data {
             assert_eq!(x.answer_id, did3);
         } else {
@@ -766,11 +766,11 @@ mod test {
         // node1 and node3 will gen JoinDHT Event
         let ev_1 = node1.listen_once().await.unwrap();
         assert_eq!(ev_1.addr, key1.address());
-        assert_eq!(ev_1.method, RelayMethod::SEND);
-        assert_eq!(ev_1.path, vec![did1]);
-        assert_eq!(ev_1.path_end_cursor, 0);
-        assert_eq!(ev_1.next_hop, None);
-        assert_eq!(ev_1.destination, did1);
+        assert_eq!(ev_1.relay.method, RelayMethod::SEND);
+        assert_eq!(ev_1.relay.path, vec![did1]);
+        assert_eq!(ev_1.relay.path_end_cursor, 0);
+        assert_eq!(ev_1.relay.next_hop, Some(did1));
+        assert_eq!(ev_1.relay.destination, did1);
 
         if let Message::JoinDHT(x) = ev_1.data {
             assert_eq!(x.id, did3);
@@ -782,11 +782,11 @@ mod test {
 
         let ev_3 = node3.listen_once().await.unwrap();
         assert_eq!(ev_3.addr, key3.address());
-        assert_eq!(ev_3.method, RelayMethod::SEND);
-        assert_eq!(ev_3.path, vec![did3]);
-        assert_eq!(ev_3.path_end_cursor, 0);
-        assert_eq!(ev_3.next_hop, None);
-        assert_eq!(ev_3.destination, did3);
+        assert_eq!(ev_3.relay.method, RelayMethod::SEND);
+        assert_eq!(ev_3.relay.path, vec![did3]);
+        assert_eq!(ev_3.relay.path_end_cursor, 0);
+        assert_eq!(ev_3.relay.next_hop, Some(did3));
+        assert_eq!(ev_3.relay.destination, did3);
 
         if let Message::JoinDHT(x) = ev_3.data {
             assert_eq!(x.id, did1);
@@ -797,11 +797,11 @@ mod test {
         let ev_1 = node1.listen_once().await.unwrap();
         // msg is send from key3
         assert_eq!(ev_1.addr, key3.address());
-        assert_eq!(ev_1.method, RelayMethod::SEND);
-        assert_eq!(ev_1.path, vec![did3]);
-        assert_eq!(ev_1.path_end_cursor, 0);
-        assert_eq!(ev_1.next_hop, Some(did1));
-        assert_eq!(ev_1.destination, did1);
+        assert_eq!(ev_1.relay.method, RelayMethod::SEND);
+        assert_eq!(ev_1.relay.path, vec![did3]);
+        assert_eq!(ev_1.relay.path_end_cursor, 0);
+        assert_eq!(ev_1.relay.next_hop, Some(did1));
+        assert_eq!(ev_1.relay.destination, did1);
         if let Message::FindSuccessorSend(x) = ev_1.data {
             assert_eq!(x.id, did3);
             assert!(!x.for_fix);
@@ -811,11 +811,11 @@ mod test {
 
         let ev_3 = node3.listen_once().await.unwrap();
         assert_eq!(ev_3.addr, key1.address());
-        assert_eq!(ev_3.method, RelayMethod::SEND);
-        assert_eq!(ev_3.path, vec![did1]);
-        assert_eq!(ev_3.path_end_cursor, 0);
-        assert_eq!(ev_3.next_hop, Some(did3));
-        assert_eq!(ev_3.destination, did3);
+        assert_eq!(ev_3.relay.method, RelayMethod::SEND);
+        assert_eq!(ev_3.relay.path, vec![did1]);
+        assert_eq!(ev_3.relay.path_end_cursor, 0);
+        assert_eq!(ev_3.relay.next_hop, Some(did3));
+        assert_eq!(ev_3.relay.destination, did3);
         if let Message::FindSuccessorSend(x) = ev_3.data {
             assert_eq!(x.id, did1);
             assert!(!x.for_fix);
@@ -826,11 +826,11 @@ mod test {
         // node3 response self as node1's successor
         let ev_1 = node1.listen_once().await.unwrap();
         assert_eq!(ev_1.addr, key3.address());
-        assert_eq!(ev_1.method, RelayMethod::REPORT);
-        assert_eq!(ev_1.path, vec![did1, did3]);
-        assert_eq!(ev_1.path_end_cursor, 0);
-        assert_eq!(ev_1.next_hop, Some(did1));
-        assert_eq!(ev_1.destination, did1);
+        assert_eq!(ev_1.relay.method, RelayMethod::REPORT);
+        assert_eq!(ev_1.relay.path, vec![did1, did3]);
+        assert_eq!(ev_1.relay.path_end_cursor, 0);
+        assert_eq!(ev_1.relay.next_hop, Some(did1));
+        assert_eq!(ev_1.relay.destination, did1);
         if let Message::FindSuccessorReport(x) = ev_1.data {
             // for node3 there is no did is more closer to key1, so it response key1
             // and dht1 wont update
@@ -844,11 +844,11 @@ mod test {
         // key1 response self as key3's successor
         let ev_3 = node3.listen_once().await.unwrap();
         assert_eq!(ev_3.addr, key1.address());
-        assert_eq!(ev_3.method, RelayMethod::REPORT);
-        assert_eq!(ev_3.path, vec![did3, did1]);
-        assert_eq!(ev_3.path_end_cursor, 0);
-        assert_eq!(ev_3.next_hop, Some(did3));
-        assert_eq!(ev_3.destination, did3);
+        assert_eq!(ev_3.relay.method, RelayMethod::REPORT);
+        assert_eq!(ev_3.relay.path, vec![did3, did1]);
+        assert_eq!(ev_3.relay.path_end_cursor, 0);
+        assert_eq!(ev_3.relay.next_hop, Some(did3));
+        assert_eq!(ev_3.relay.destination, did3);
         if let Message::FindSuccessorReport(x) = ev_3.data {
             // for key1 there is no did is more closer to key1, so it response key1
             // and dht3 wont update
@@ -901,11 +901,11 @@ mod test {
         // node2 and node3 will gen JoinDHT Event
         let ev_2 = node2.listen_once().await.unwrap();
         assert_eq!(ev_2.addr, key2.address());
-        assert_eq!(ev_2.method, RelayMethod::SEND);
-        assert_eq!(ev_2.path, vec![did2]);
-        assert_eq!(ev_2.path_end_cursor, 0);
-        assert_eq!(ev_2.next_hop, None);
-        assert_eq!(ev_2.destination, did2);
+        assert_eq!(ev_2.relay.method, RelayMethod::SEND);
+        assert_eq!(ev_2.relay.path, vec![did2]);
+        assert_eq!(ev_2.relay.path_end_cursor, 0);
+        assert_eq!(ev_2.relay.next_hop, Some(did2));
+        assert_eq!(ev_2.relay.destination, did2);
 
         if let Message::JoinDHT(x) = ev_2.data {
             assert_eq!(x.id, did3);
@@ -917,11 +917,11 @@ mod test {
 
         let ev_3 = node3.listen_once().await.unwrap();
         assert_eq!(ev_3.addr, key3.address());
-        assert_eq!(ev_3.method, RelayMethod::SEND);
-        assert_eq!(ev_3.path, vec![did3]);
-        assert_eq!(ev_3.path_end_cursor, 0);
-        assert_eq!(ev_3.next_hop, None);
-        assert_eq!(ev_3.destination, did3);
+        assert_eq!(ev_3.relay.method, RelayMethod::SEND);
+        assert_eq!(ev_3.relay.path, vec![did3]);
+        assert_eq!(ev_3.relay.path_end_cursor, 0);
+        assert_eq!(ev_3.relay.next_hop, Some(did3));
+        assert_eq!(ev_3.relay.destination, did3);
 
         if let Message::JoinDHT(x) = ev_3.data {
             assert_eq!(x.id, did2);
@@ -933,11 +933,11 @@ mod test {
         // msg is send from key3
         // node 3 ask node 2 for successor
         assert_eq!(ev_2.addr, key3.address());
-        assert_eq!(ev_2.method, RelayMethod::SEND);
-        assert_eq!(ev_2.path, vec![did3]);
-        assert_eq!(ev_2.path_end_cursor, 0);
-        assert_eq!(ev_2.next_hop, Some(did2));
-        assert_eq!(ev_2.destination, did2);
+        assert_eq!(ev_2.relay.method, RelayMethod::SEND);
+        assert_eq!(ev_2.relay.path, vec![did3]);
+        assert_eq!(ev_2.relay.path_end_cursor, 0);
+        assert_eq!(ev_2.relay.next_hop, Some(did2));
+        assert_eq!(ev_2.relay.destination, did2);
         if let Message::FindSuccessorSend(x) = ev_2.data {
             assert_eq!(x.id, did3);
             assert!(!x.for_fix);
@@ -949,11 +949,11 @@ mod test {
         // node 3 will ask it's successor: node 1
         let ev_3 = node3.listen_once().await.unwrap();
         assert_eq!(ev_3.addr, key2.address());
-        assert_eq!(ev_3.method, RelayMethod::SEND);
-        assert_eq!(ev_3.path, vec![did2]);
-        assert_eq!(ev_3.path_end_cursor, 0);
-        assert_eq!(ev_3.next_hop, Some(did3));
-        assert_eq!(ev_3.destination, did3);
+        assert_eq!(ev_3.relay.method, RelayMethod::SEND);
+        assert_eq!(ev_3.relay.path, vec![did2]);
+        assert_eq!(ev_3.relay.path_end_cursor, 0);
+        assert_eq!(ev_3.relay.next_hop, Some(did3));
+        assert_eq!(ev_3.relay.destination, did3);
         if let Message::FindSuccessorSend(x) = ev_3.data {
             assert_eq!(x.id, did2);
             assert!(!x.for_fix);
@@ -965,11 +965,11 @@ mod test {
         // node 2 report node2's successor is node 3
         let ev_3 = node3.listen_once().await.unwrap();
         assert_eq!(ev_3.addr, key2.address());
-        assert_eq!(ev_3.method, RelayMethod::REPORT);
-        assert_eq!(ev_3.path, vec![did3, did2]);
-        assert_eq!(ev_3.path_end_cursor, 0);
-        assert_eq!(ev_3.next_hop, Some(did3));
-        assert_eq!(ev_3.destination, did3);
+        assert_eq!(ev_3.relay.method, RelayMethod::REPORT);
+        assert_eq!(ev_3.relay.path, vec![did3, did2]);
+        assert_eq!(ev_3.relay.path_end_cursor, 0);
+        assert_eq!(ev_3.relay.next_hop, Some(did3));
+        assert_eq!(ev_3.relay.destination, did3);
         if let Message::FindSuccessorReport(x) = ev_3.data {
             assert_eq!(x.id, did3);
             assert!(!x.for_fix);
@@ -988,11 +988,11 @@ mod test {
         // the msg is send from node 3 to node 1
         let ev_1 = node1.listen_once().await.unwrap();
         assert_eq!(ev_1.addr, key3.address());
-        assert_eq!(ev_1.method, RelayMethod::SEND);
-        assert_eq!(ev_1.path, vec![did2, did3]);
-        assert_eq!(ev_1.path_end_cursor, 0);
-        assert_eq!(ev_1.next_hop, Some(did1));
-        assert_eq!(ev_1.destination, did1);
+        assert_eq!(ev_1.relay.method, RelayMethod::SEND);
+        assert_eq!(ev_1.relay.path, vec![did2, did3]);
+        assert_eq!(ev_1.relay.path_end_cursor, 0);
+        assert_eq!(ev_1.relay.next_hop, Some(did1));
+        assert_eq!(ev_1.relay.destination, did1);
         if let Message::FindSuccessorSend(x) = ev_1.data {
             assert_eq!(x.id, did2);
             assert!(!x.for_fix);
@@ -1015,11 +1015,11 @@ mod test {
         // path is node2 -> node3 -> node1 -> node3
         let ev_3 = node3.listen_once().await.unwrap();
         assert_eq!(ev_3.addr, key1.address());
-        assert_eq!(ev_3.method, RelayMethod::REPORT);
-        assert_eq!(ev_3.path, vec![did2, did3, did1]);
-        assert_eq!(ev_3.path_end_cursor, 0);
-        assert_eq!(ev_3.next_hop, Some(did3));
-        assert_eq!(ev_3.destination, did2);
+        assert_eq!(ev_3.relay.method, RelayMethod::REPORT);
+        assert_eq!(ev_3.relay.path, vec![did2, did3, did1]);
+        assert_eq!(ev_3.relay.path_end_cursor, 0);
+        assert_eq!(ev_3.relay.next_hop, Some(did3));
+        assert_eq!(ev_3.relay.destination, did2);
         if let Message::FindSuccessorReport(x) = ev_3.data {
             assert_eq!(x.id, did3);
             assert!(!x.for_fix);
@@ -1031,11 +1031,11 @@ mod test {
         // path is: node 2 -> node3 -> node1 -> node3 -> node2
         let ev_2 = node2.listen_once().await.unwrap();
         assert_eq!(ev_2.addr, key3.address());
-        assert_eq!(ev_2.method, RelayMethod::REPORT);
-        assert_eq!(ev_2.path, vec![did2, did3, did1]);
-        assert_eq!(ev_2.path_end_cursor, 1);
-        assert_eq!(ev_2.next_hop, Some(did2));
-        assert_eq!(ev_2.destination, did2);
+        assert_eq!(ev_2.relay.method, RelayMethod::REPORT);
+        assert_eq!(ev_2.relay.path, vec![did2, did3, did1]);
+        assert_eq!(ev_2.relay.path_end_cursor, 1);
+        assert_eq!(ev_2.relay.next_hop, Some(did2));
+        assert_eq!(ev_2.relay.destination, did2);
 
         if let Message::FindSuccessorReport(x) = ev_2.data {
             assert_eq!(x.id, did3);

--- a/rings-core/src/message/handlers/connection.rs
+++ b/rings-core/src/message/handlers/connection.rs
@@ -1,15 +1,14 @@
 use crate::dht::ChordStorage;
 use crate::dht::{Chord, ChordStablize, PeerRingAction, PeerRingRemoteAction};
 use crate::err::{Error, Result};
-use crate::message::payload::{MessageRelay, MessageRelayMethod};
-use crate::message::protocol::MessageSessionRelayProtocol;
 use crate::message::types::{
     AlreadyConnected, ConnectNodeReport, ConnectNodeSend, FindSuccessorReport, FindSuccessorSend,
     JoinDHT, Message, NotifyPredecessorReport, NotifyPredecessorSend, SyncVNodeWithSuccessor,
 };
+use crate::message::HandleMsg;
 use crate::message::LeaveDHT;
 use crate::message::MessageHandler;
-use crate::message::OriginVerificationGen;
+use crate::message::{MessagePayload, PayloadSender, RelayMethod};
 use crate::prelude::RTCSdpType;
 use crate::swarm::TransportManager;
 use crate::types::ice_transport::IceTrickleScheme;
@@ -18,60 +17,18 @@ use std::str::FromStr;
 
 #[cfg_attr(feature = "wasm", async_trait(?Send))]
 #[cfg_attr(not(feature = "wasm"), async_trait)]
-pub trait TChordConnection {
-    async fn join_chord(&self, relay: MessageRelay<Message>, msg: JoinDHT) -> Result<()>;
-
-    async fn leave_chord(&self, relay: MessageRelay<Message>, msg: LeaveDHT) -> Result<()>;
-
-    async fn connect_node(&self, relay: MessageRelay<Message>, msg: ConnectNodeSend) -> Result<()>;
-
-    async fn connected_node(
-        &self,
-        relay: MessageRelay<Message>,
-        msg: ConnectNodeReport,
-    ) -> Result<()>;
-
-    async fn already_connected(
-        &self,
-        relay: MessageRelay<Message>,
-        msg: AlreadyConnected,
-    ) -> Result<()>;
-
-    async fn find_successor(
-        &self,
-        relay: MessageRelay<Message>,
-        msg: FindSuccessorSend,
-    ) -> Result<()>;
-
-    async fn found_successor(
-        &self,
-        relay: MessageRelay<Message>,
-        msg: FindSuccessorReport,
-    ) -> Result<()>;
-
-    async fn notify_predecessor(
-        &self,
-        relay: MessageRelay<Message>,
-        msg: NotifyPredecessorSend,
-    ) -> Result<()>;
-
-    async fn notified_predecessor(
-        &self,
-        relay: MessageRelay<Message>,
-        msg: NotifyPredecessorReport,
-    ) -> Result<()>;
-}
-
-#[cfg_attr(feature = "wasm", async_trait(?Send))]
-#[cfg_attr(not(feature = "wasm"), async_trait)]
-impl TChordConnection for MessageHandler {
-    async fn leave_chord(&self, _relay: MessageRelay<Message>, msg: LeaveDHT) -> Result<()> {
+impl HandleMsg<LeaveDHT> for MessageHandler {
+    async fn handle(&self, _ctx: &MessagePayload<Message>, msg: &LeaveDHT) -> Result<()> {
         let mut dht = self.dht.lock().await;
         dht.remove(msg.id);
         Ok(())
     }
+}
 
-    async fn join_chord(&self, relay: MessageRelay<Message>, msg: JoinDHT) -> Result<()> {
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
+impl HandleMsg<JoinDHT> for MessageHandler {
+    async fn handle(&self, ctx: &MessagePayload<Message>, msg: &JoinDHT) -> Result<()> {
         // here is two situation.
         // finger table just have no other node(beside next), it will be a `create` op
         // otherwise, it will be a `send` op
@@ -83,17 +40,11 @@ impl TChordConnection for MessageHandler {
                 // A.successor == B
                 // B.successor == A
                 // A.find_successor(B)
-                if next != relay.addr.into() {
-                    self.send_relay_message(MessageRelay::new(
+                if next != ctx.addr.into() {
+                    self.send_direct_message(
                         Message::FindSuccessorSend(FindSuccessorSend { id, for_fix: false }),
-                        &self.swarm.session_manager,
-                        OriginVerificationGen::Origin,
-                        MessageRelayMethod::SEND,
-                        None,
-                        None,
-                        Some(next),
                         next,
-                    )?)
+                    )
                     .await
                 } else {
                     Ok(())
@@ -102,10 +53,15 @@ impl TChordConnection for MessageHandler {
             _ => unreachable!(),
         }
     }
+}
 
-    async fn connect_node(&self, relay: MessageRelay<Message>, msg: ConnectNodeSend) -> Result<()> {
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
+impl HandleMsg<ConnectNodeSend> for MessageHandler {
+    async fn handle(&self, ctx: &MessagePayload<Message>, msg: &ConnectNodeSend) -> Result<()> {
         let dht = self.dht.lock().await;
-        let mut relay = relay.clone();
+        let mut relay = ctx.relay.clone();
+
         if dht.id != msg.target_id {
             let next_node = match dht.find_successor(msg.target_id)? {
                 PeerRingAction::Some(node) => Some(node),
@@ -114,13 +70,7 @@ impl TChordConnection for MessageHandler {
             }
             .ok_or(Error::MessageHandlerMissNextNode)?;
             relay.relay(dht.id, Some(next_node))?;
-            return self
-                .send_relay_message(relay.rewrap(
-                    relay.data.clone(),
-                    &self.swarm.session_manager,
-                    OriginVerificationGen::Stick(relay.origin_verification.clone()),
-                )?)
-                .await;
+            return self.transpond_payload(ctx, relay).await;
         }
 
         relay.relay(dht.id, None)?;
@@ -134,14 +84,14 @@ impl TChordConnection for MessageHandler {
                     .get_handshake_info(&self.swarm.session_manager, RTCSdpType::Answer)
                     .await?
                     .to_string();
-                self.send_relay_message(relay.report(
+                self.send_report_message(
                     Message::ConnectNodeReport(ConnectNodeReport {
                         answer_id: dht.id,
                         transport_uuid: msg.transport_uuid.clone(),
                         handshake_info,
                     }),
-                    &self.swarm.session_manager,
-                )?)
+                    relay,
+                )
                 .await?;
                 self.swarm.get_or_register(&msg.sender_id, trans).await?;
 
@@ -149,30 +99,26 @@ impl TChordConnection for MessageHandler {
             }
 
             _ => {
-                self.send_relay_message(relay.report(
+                self.send_report_message(
                     Message::AlreadyConnected(AlreadyConnected { answer_id: dht.id }),
-                    &self.swarm.session_manager,
-                )?)
+                    relay,
+                )
                 .await
             }
         }
     }
+}
 
-    async fn connected_node(
-        &self,
-        relay: MessageRelay<Message>,
-        msg: ConnectNodeReport,
-    ) -> Result<()> {
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
+impl HandleMsg<ConnectNodeReport> for MessageHandler {
+    async fn handle(&self, ctx: &MessagePayload<Message>, msg: &ConnectNodeReport) -> Result<()> {
         let dht = self.dht.lock().await;
-        let mut relay = relay.clone();
+        let mut relay = ctx.relay.clone();
+
         relay.relay(dht.id, None)?;
         if relay.next_hop.is_some() {
-            self.send_relay_message(relay.rewrap(
-                relay.data.clone(),
-                &self.swarm.session_manager,
-                OriginVerificationGen::Stick(relay.origin_verification.clone()),
-            )?)
-            .await
+            self.transpond_payload(ctx, relay).await
         } else {
             let transport = self
                 .swarm
@@ -187,22 +133,18 @@ impl TChordConnection for MessageHandler {
             self.swarm.register(&msg.answer_id, transport).await
         }
     }
+}
 
-    async fn already_connected(
-        &self,
-        relay: MessageRelay<Message>,
-        msg: AlreadyConnected,
-    ) -> Result<()> {
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
+impl HandleMsg<AlreadyConnected> for MessageHandler {
+    async fn handle(&self, ctx: &MessagePayload<Message>, msg: &AlreadyConnected) -> Result<()> {
         let dht = self.dht.lock().await;
-        let mut relay = relay.clone();
+        let mut relay = ctx.relay.clone();
+
         relay.relay(dht.id, None)?;
         if relay.next_hop.is_some() {
-            self.send_relay_message(relay.rewrap(
-                relay.data.clone(),
-                &self.swarm.session_manager,
-                OriginVerificationGen::Stick(relay.origin_verification.clone()),
-            )?)
-            .await
+            self.transpond_payload(ctx, relay).await
         } else {
             self.swarm
                 .get_transport(&msg.answer_id)
@@ -210,55 +152,47 @@ impl TChordConnection for MessageHandler {
                 .ok_or(Error::MessageHandlerMissTransportAlreadyConnected)
         }
     }
+}
 
-    async fn find_successor(
-        &self,
-        relay: MessageRelay<Message>,
-        msg: FindSuccessorSend,
-    ) -> Result<()> {
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
+impl HandleMsg<FindSuccessorSend> for MessageHandler {
+    async fn handle(&self, ctx: &MessagePayload<Message>, msg: &FindSuccessorSend) -> Result<()> {
         let dht = self.dht.lock().await;
-        let mut relay = relay.clone();
+        let mut relay = ctx.relay.clone();
+
         match dht.find_successor(msg.id)? {
             PeerRingAction::Some(id) => {
                 relay.relay(dht.id, None)?;
-                self.send_relay_message(relay.report(
+                self.send_report_message(
                     Message::FindSuccessorReport(FindSuccessorReport {
                         id,
                         for_fix: msg.for_fix,
                     }),
-                    &self.swarm.session_manager,
-                )?)
+                    relay,
+                )
                 .await
             }
             PeerRingAction::RemoteAction(next, _) => {
                 relay.relay(dht.id, Some(next))?;
                 relay.reset_destination(next)?;
-                self.send_relay_message(relay.rewrap(
-                    relay.data.clone(),
-                    &self.swarm.session_manager,
-                    OriginVerificationGen::Stick(relay.origin_verification.clone()),
-                )?)
-                .await
+                self.transpond_payload(ctx, relay).await
             }
             act => Err(Error::PeerRingUnexpectedAction(act)),
         }
     }
+}
 
-    async fn found_successor(
-        &self,
-        relay: MessageRelay<Message>,
-        msg: FindSuccessorReport,
-    ) -> Result<()> {
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
+impl HandleMsg<FindSuccessorReport> for MessageHandler {
+    async fn handle(&self, ctx: &MessagePayload<Message>, msg: &FindSuccessorReport) -> Result<()> {
         let mut dht = self.dht.lock().await;
-        let mut relay = relay.clone();
+        let mut relay = ctx.relay.clone();
+
         relay.relay(dht.id, None)?;
         if relay.next_hop.is_some() {
-            self.send_relay_message(relay.rewrap(
-                relay.data.clone(),
-                &self.swarm.session_manager,
-                OriginVerificationGen::Stick(relay.origin_verification.clone()),
-            )?)
-            .await
+            self.transpond_payload(ctx, relay).await
         } else {
             if self.swarm.get_transport(&msg.id).is_none() && msg.id != self.swarm.address().into()
             {
@@ -274,43 +208,52 @@ impl TChordConnection for MessageHandler {
                     PeerRingRemoteAction::SyncVNodeWithSuccessor(data),
                 )) = dht.sync_with_successor(msg.id)
                 {
-                    self.send_relay_message(MessageRelay::direct(
+                    self.send_direct_message(
                         Message::SyncVNodeWithSuccessor(SyncVNodeWithSuccessor { data }),
-                        &self.swarm.session_manager,
                         next,
-                    )?)
+                    )
                     .await?;
                 }
             }
             Ok(())
         }
     }
+}
 
-    async fn notify_predecessor(
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
+impl HandleMsg<NotifyPredecessorSend> for MessageHandler {
+    async fn handle(
         &self,
-        relay: MessageRelay<Message>,
-        msg: NotifyPredecessorSend,
+        ctx: &MessagePayload<Message>,
+        msg: &NotifyPredecessorSend,
     ) -> Result<()> {
         let mut dht = self.dht.lock().await;
-        let mut relay = relay.clone();
+        let mut relay = ctx.relay.clone();
+
         relay.relay(dht.id, None)?;
         dht.notify(msg.id);
-        self.send_relay_message(relay.report(
+        self.send_report_message(
             Message::NotifyPredecessorReport(NotifyPredecessorReport { id: dht.id }),
-            &self.swarm.session_manager,
-        )?)
+            relay,
+        )
         .await
     }
+}
 
-    async fn notified_predecessor(
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
+impl HandleMsg<NotifyPredecessorReport> for MessageHandler {
+    async fn handle(
         &self,
-        relay: MessageRelay<Message>,
-        msg: NotifyPredecessorReport,
+        ctx: &MessagePayload<Message>,
+        msg: &NotifyPredecessorReport,
     ) -> Result<()> {
         let mut dht = self.dht.lock().await;
-        let mut relay = relay.clone();
+        let mut relay = ctx.relay.clone();
+
         relay.relay(dht.id, None)?;
-        assert_eq!(relay.method, MessageRelayMethod::REPORT);
+        assert_eq!(relay.method, RelayMethod::REPORT);
         // if successor: predecessor is between (id, successor]
         // then update local successor
         dht.successor.update(msg.id);
@@ -319,11 +262,10 @@ impl TChordConnection for MessageHandler {
             PeerRingRemoteAction::SyncVNodeWithSuccessor(data),
         )) = dht.sync_with_successor(msg.id)
         {
-            self.send_relay_message(MessageRelay::direct(
+            self.send_direct_message(
                 Message::SyncVNodeWithSuccessor(SyncVNodeWithSuccessor { data }),
-                &self.swarm.session_manager,
                 next,
-            )?)
+            )
             .await?;
         }
         Ok(())
@@ -430,7 +372,7 @@ mod test {
 
         // JoinDHT
         let ev_1 = node1.listen_once().await.unwrap();
-        assert_eq!(ev_1.method, MessageRelayMethod::SEND);
+        assert_eq!(ev_1.method, RelayMethod::SEND);
         assert_eq!(ev_1.path, vec![did1]);
         assert_eq!(ev_1.path_end_cursor, 0);
         assert_eq!(ev_1.next_hop, None);
@@ -445,7 +387,7 @@ mod test {
         assert_eq!(&ev_1.addr, &key1.address());
 
         let ev_2 = node2.listen_once().await.unwrap();
-        assert_eq!(ev_2.method, MessageRelayMethod::SEND);
+        assert_eq!(ev_2.method, RelayMethod::SEND);
         assert_eq!(ev_2.path, vec![did2]);
         assert_eq!(ev_2.path_end_cursor, 0);
         assert_eq!(ev_2.next_hop, None);
@@ -462,7 +404,7 @@ mod test {
         let ev_1 = node1.listen_once().await.unwrap();
         // msg is send from key2
         assert_eq!(ev_1.addr, key2.address());
-        assert_eq!(ev_1.method, MessageRelayMethod::SEND);
+        assert_eq!(ev_1.method, RelayMethod::SEND);
         assert_eq!(ev_1.path, vec![did2]);
         assert_eq!(ev_1.path_end_cursor, 0);
         assert_eq!(ev_1.next_hop, Some(did1));
@@ -476,7 +418,7 @@ mod test {
 
         let ev_2 = node2.listen_once().await.unwrap();
         assert_eq!(ev_2.addr, key1.address());
-        assert_eq!(ev_2.method, MessageRelayMethod::SEND);
+        assert_eq!(ev_2.method, RelayMethod::SEND);
         assert_eq!(ev_2.path, vec![did1]);
         assert_eq!(ev_2.path_end_cursor, 0);
         assert_eq!(ev_2.next_hop, Some(did2));
@@ -491,7 +433,7 @@ mod test {
         // node2 response self as node1's successor
         let ev_1 = node1.listen_once().await.unwrap();
         assert_eq!(ev_1.addr, key2.address());
-        assert_eq!(ev_1.method, MessageRelayMethod::REPORT);
+        assert_eq!(ev_1.method, RelayMethod::REPORT);
         assert_eq!(ev_1.path, vec![did1, did2]);
         assert_eq!(ev_1.path_end_cursor, 0);
         assert_eq!(ev_1.next_hop, Some(did1));
@@ -509,7 +451,7 @@ mod test {
         // key1 response self as key2's successor
         let ev_2 = node2.listen_once().await.unwrap();
         assert_eq!(ev_2.addr, key1.address());
-        assert_eq!(ev_2.method, MessageRelayMethod::REPORT);
+        assert_eq!(ev_2.method, RelayMethod::REPORT);
         assert_eq!(ev_2.path, vec![did2, did1]);
         assert_eq!(ev_2.path_end_cursor, 0);
         assert_eq!(ev_2.next_hop, Some(did2));
@@ -563,7 +505,7 @@ mod test {
 
         let ev_3 = node3.listen_once().await.unwrap();
         assert_eq!(ev_3.addr, key3.address());
-        assert_eq!(ev_3.method, MessageRelayMethod::SEND);
+        assert_eq!(ev_3.method, RelayMethod::SEND);
         assert_eq!(ev_3.path, vec![did3]);
         assert_eq!(ev_3.path_end_cursor, 0);
         assert_eq!(ev_3.next_hop, None);
@@ -576,7 +518,7 @@ mod test {
 
         let ev_2 = node2.listen_once().await.unwrap();
         assert_eq!(ev_2.addr, key2.address());
-        assert_eq!(ev_2.method, MessageRelayMethod::SEND);
+        assert_eq!(ev_2.method, RelayMethod::SEND);
         assert_eq!(ev_2.path, vec![did2]);
         assert_eq!(ev_2.path_end_cursor, 0);
         assert_eq!(ev_2.next_hop, None);
@@ -590,7 +532,7 @@ mod test {
         let ev_3 = node3.listen_once().await.unwrap();
         // msg is send from node2
         assert_eq!(ev_3.addr, key2.address());
-        assert_eq!(ev_3.method, MessageRelayMethod::SEND);
+        assert_eq!(ev_3.method, RelayMethod::SEND);
         assert_eq!(ev_3.path, vec![did2]);
         assert_eq!(ev_3.path_end_cursor, 0);
         assert_eq!(ev_3.next_hop, Some(did3));
@@ -604,7 +546,7 @@ mod test {
 
         let ev_2 = node2.listen_once().await.unwrap();
         assert_eq!(ev_2.addr, key3.address());
-        assert_eq!(ev_2.method, MessageRelayMethod::SEND);
+        assert_eq!(ev_2.method, RelayMethod::SEND);
         assert_eq!(ev_2.path, vec![did3]);
         assert_eq!(ev_2.path_end_cursor, 0);
         assert_eq!(ev_2.next_hop, Some(did2));
@@ -619,7 +561,7 @@ mod test {
         // node2 response self as node1's successor
         let ev_3 = node3.listen_once().await.unwrap();
         assert_eq!(ev_3.addr, key2.address());
-        assert_eq!(ev_3.method, MessageRelayMethod::REPORT);
+        assert_eq!(ev_3.method, RelayMethod::REPORT);
         assert_eq!(ev_3.path, vec![did3, did2]);
         assert_eq!(ev_3.path_end_cursor, 0);
         assert_eq!(ev_3.next_hop, Some(did3));
@@ -637,7 +579,7 @@ mod test {
         // key3 response self as key2's successor
         let ev_2 = node2.listen_once().await.unwrap();
         assert_eq!(ev_2.addr, key3.address());
-        assert_eq!(ev_2.method, MessageRelayMethod::REPORT);
+        assert_eq!(ev_2.method, RelayMethod::REPORT);
         assert_eq!(ev_2.path, vec![did2, did3]);
         assert_eq!(ev_2.path_end_cursor, 0);
         assert_eq!(ev_2.next_hop, Some(did2));
@@ -664,7 +606,7 @@ mod test {
 
         // msg is send from node 1 to node 2
         assert_eq!(ev2.addr, key1.address());
-        assert_eq!(ev2.method, MessageRelayMethod::SEND);
+        assert_eq!(ev2.method, RelayMethod::SEND);
         assert_eq!(ev2.path, vec![did1]);
         assert_eq!(ev2.path_end_cursor, 0);
         assert_eq!(ev2.next_hop, Some(did2));
@@ -688,7 +630,7 @@ mod test {
         );
 
         assert_eq!(ev3.addr, key2.address());
-        assert_eq!(ev3.method, MessageRelayMethod::SEND);
+        assert_eq!(ev3.method, RelayMethod::SEND);
         assert_eq!(ev3.path, vec![did1, did2]);
         assert_eq!(ev3.path_end_cursor, 0);
         assert_eq!(ev3.next_hop, Some(did3));
@@ -703,7 +645,7 @@ mod test {
         let ev2 = node2.listen_once().await.unwrap();
         // node3 send report to node2
         assert_eq!(ev2.addr, key3.address());
-        assert_eq!(ev2.method, MessageRelayMethod::REPORT);
+        assert_eq!(ev2.method, RelayMethod::REPORT);
         assert_eq!(ev2.path, vec![did1, did2, did3]);
         assert_eq!(ev2.path_end_cursor, 0);
         assert_eq!(ev2.next_hop, Some(did2));
@@ -716,7 +658,7 @@ mod test {
         // node 2 send report to node1
         let ev1 = node1.listen_once().await.unwrap();
         assert_eq!(ev1.addr, key2.address());
-        assert_eq!(ev1.method, MessageRelayMethod::REPORT);
+        assert_eq!(ev1.method, RelayMethod::REPORT);
         assert_eq!(ev1.path, vec![did1, did2, did3]);
         assert_eq!(ev1.path_end_cursor, 1);
         assert_eq!(ev1.next_hop, Some(did1));
@@ -824,7 +766,7 @@ mod test {
         // node1 and node3 will gen JoinDHT Event
         let ev_1 = node1.listen_once().await.unwrap();
         assert_eq!(ev_1.addr, key1.address());
-        assert_eq!(ev_1.method, MessageRelayMethod::SEND);
+        assert_eq!(ev_1.method, RelayMethod::SEND);
         assert_eq!(ev_1.path, vec![did1]);
         assert_eq!(ev_1.path_end_cursor, 0);
         assert_eq!(ev_1.next_hop, None);
@@ -840,7 +782,7 @@ mod test {
 
         let ev_3 = node3.listen_once().await.unwrap();
         assert_eq!(ev_3.addr, key3.address());
-        assert_eq!(ev_3.method, MessageRelayMethod::SEND);
+        assert_eq!(ev_3.method, RelayMethod::SEND);
         assert_eq!(ev_3.path, vec![did3]);
         assert_eq!(ev_3.path_end_cursor, 0);
         assert_eq!(ev_3.next_hop, None);
@@ -855,7 +797,7 @@ mod test {
         let ev_1 = node1.listen_once().await.unwrap();
         // msg is send from key3
         assert_eq!(ev_1.addr, key3.address());
-        assert_eq!(ev_1.method, MessageRelayMethod::SEND);
+        assert_eq!(ev_1.method, RelayMethod::SEND);
         assert_eq!(ev_1.path, vec![did3]);
         assert_eq!(ev_1.path_end_cursor, 0);
         assert_eq!(ev_1.next_hop, Some(did1));
@@ -869,7 +811,7 @@ mod test {
 
         let ev_3 = node3.listen_once().await.unwrap();
         assert_eq!(ev_3.addr, key1.address());
-        assert_eq!(ev_3.method, MessageRelayMethod::SEND);
+        assert_eq!(ev_3.method, RelayMethod::SEND);
         assert_eq!(ev_3.path, vec![did1]);
         assert_eq!(ev_3.path_end_cursor, 0);
         assert_eq!(ev_3.next_hop, Some(did3));
@@ -884,7 +826,7 @@ mod test {
         // node3 response self as node1's successor
         let ev_1 = node1.listen_once().await.unwrap();
         assert_eq!(ev_1.addr, key3.address());
-        assert_eq!(ev_1.method, MessageRelayMethod::REPORT);
+        assert_eq!(ev_1.method, RelayMethod::REPORT);
         assert_eq!(ev_1.path, vec![did1, did3]);
         assert_eq!(ev_1.path_end_cursor, 0);
         assert_eq!(ev_1.next_hop, Some(did1));
@@ -902,7 +844,7 @@ mod test {
         // key1 response self as key3's successor
         let ev_3 = node3.listen_once().await.unwrap();
         assert_eq!(ev_3.addr, key1.address());
-        assert_eq!(ev_3.method, MessageRelayMethod::REPORT);
+        assert_eq!(ev_3.method, RelayMethod::REPORT);
         assert_eq!(ev_3.path, vec![did3, did1]);
         assert_eq!(ev_3.path_end_cursor, 0);
         assert_eq!(ev_3.next_hop, Some(did3));
@@ -959,7 +901,7 @@ mod test {
         // node2 and node3 will gen JoinDHT Event
         let ev_2 = node2.listen_once().await.unwrap();
         assert_eq!(ev_2.addr, key2.address());
-        assert_eq!(ev_2.method, MessageRelayMethod::SEND);
+        assert_eq!(ev_2.method, RelayMethod::SEND);
         assert_eq!(ev_2.path, vec![did2]);
         assert_eq!(ev_2.path_end_cursor, 0);
         assert_eq!(ev_2.next_hop, None);
@@ -975,7 +917,7 @@ mod test {
 
         let ev_3 = node3.listen_once().await.unwrap();
         assert_eq!(ev_3.addr, key3.address());
-        assert_eq!(ev_3.method, MessageRelayMethod::SEND);
+        assert_eq!(ev_3.method, RelayMethod::SEND);
         assert_eq!(ev_3.path, vec![did3]);
         assert_eq!(ev_3.path_end_cursor, 0);
         assert_eq!(ev_3.next_hop, None);
@@ -991,7 +933,7 @@ mod test {
         // msg is send from key3
         // node 3 ask node 2 for successor
         assert_eq!(ev_2.addr, key3.address());
-        assert_eq!(ev_2.method, MessageRelayMethod::SEND);
+        assert_eq!(ev_2.method, RelayMethod::SEND);
         assert_eq!(ev_2.path, vec![did3]);
         assert_eq!(ev_2.path_end_cursor, 0);
         assert_eq!(ev_2.next_hop, Some(did2));
@@ -1007,7 +949,7 @@ mod test {
         // node 3 will ask it's successor: node 1
         let ev_3 = node3.listen_once().await.unwrap();
         assert_eq!(ev_3.addr, key2.address());
-        assert_eq!(ev_3.method, MessageRelayMethod::SEND);
+        assert_eq!(ev_3.method, RelayMethod::SEND);
         assert_eq!(ev_3.path, vec![did2]);
         assert_eq!(ev_3.path_end_cursor, 0);
         assert_eq!(ev_3.next_hop, Some(did3));
@@ -1023,7 +965,7 @@ mod test {
         // node 2 report node2's successor is node 3
         let ev_3 = node3.listen_once().await.unwrap();
         assert_eq!(ev_3.addr, key2.address());
-        assert_eq!(ev_3.method, MessageRelayMethod::REPORT);
+        assert_eq!(ev_3.method, RelayMethod::REPORT);
         assert_eq!(ev_3.path, vec![did3, did2]);
         assert_eq!(ev_3.path_end_cursor, 0);
         assert_eq!(ev_3.next_hop, Some(did3));
@@ -1046,7 +988,7 @@ mod test {
         // the msg is send from node 3 to node 1
         let ev_1 = node1.listen_once().await.unwrap();
         assert_eq!(ev_1.addr, key3.address());
-        assert_eq!(ev_1.method, MessageRelayMethod::SEND);
+        assert_eq!(ev_1.method, RelayMethod::SEND);
         assert_eq!(ev_1.path, vec![did2, did3]);
         assert_eq!(ev_1.path_end_cursor, 0);
         assert_eq!(ev_1.next_hop, Some(did1));
@@ -1073,7 +1015,7 @@ mod test {
         // path is node2 -> node3 -> node1 -> node3
         let ev_3 = node3.listen_once().await.unwrap();
         assert_eq!(ev_3.addr, key1.address());
-        assert_eq!(ev_3.method, MessageRelayMethod::REPORT);
+        assert_eq!(ev_3.method, RelayMethod::REPORT);
         assert_eq!(ev_3.path, vec![did2, did3, did1]);
         assert_eq!(ev_3.path_end_cursor, 0);
         assert_eq!(ev_3.next_hop, Some(did3));
@@ -1089,7 +1031,7 @@ mod test {
         // path is: node 2 -> node3 -> node1 -> node3 -> node2
         let ev_2 = node2.listen_once().await.unwrap();
         assert_eq!(ev_2.addr, key3.address());
-        assert_eq!(ev_2.method, MessageRelayMethod::REPORT);
+        assert_eq!(ev_2.method, RelayMethod::REPORT);
         assert_eq!(ev_2.path, vec![did2, did3, did1]);
         assert_eq!(ev_2.path_end_cursor, 1);
         assert_eq!(ev_2.next_hop, Some(did2));

--- a/rings-core/src/message/handlers/mod.rs
+++ b/rings-core/src/message/handlers/mod.rs
@@ -134,7 +134,7 @@ impl MessageHandler {
             Message::MultiCall(ref msg) => {
                 for message in msg.messages.iter().cloned() {
                     let payload = MessagePayload::new(
-                        message.clone(),
+                        message,
                         &self.swarm.session_manager,
                         OriginVerificationGen::Stick(payload.origin_verification.clone()),
                         payload.relay.clone(),
@@ -149,7 +149,7 @@ impl MessageHandler {
                 x
             ))),
         }?;
-        if let Err(e) = self.invoke_callback(&payload).await {
+        if let Err(e) = self.invoke_callback(payload).await {
             log::warn!("invoke callback error: {}", e);
         }
 
@@ -250,6 +250,7 @@ mod listener {
 #[cfg(test)]
 pub mod test {
     use super::*;
+    use crate::dht::Did;
     use crate::dht::PeerRing;
     use crate::ecc::SecretKey;
     use crate::message::MessageHandler;

--- a/rings-core/src/message/handlers/mod.rs
+++ b/rings-core/src/message/handlers/mod.rs
@@ -1,18 +1,17 @@
-use super::{CustomMessage, MaybeEncrypted};
-use crate::dht::{Did, PeerRing};
+use super::{
+    CustomMessage, MaybeEncrypted, Message, MessagePayload, OriginVerificationGen, PayloadSender,
+};
+use crate::dht::PeerRing;
 use crate::err::{Error, Result};
-use crate::message::payload::{MessageRelay, MessageRelayMethod, OriginVerificationGen};
-use crate::message::types::Message;
 use crate::prelude::RTCSdpType;
+use crate::session::SessionManager;
 use crate::swarm::Swarm;
 use crate::swarm::TransportManager;
 use crate::types::ice_transport::IceTrickleScheme;
 use async_recursion::async_recursion;
 use async_trait::async_trait;
-use connection::TChordConnection;
 use futures::lock::Mutex;
 use std::sync::Arc;
-use storage::TChordStorage;
 use web3::types::Address;
 
 pub mod connection;
@@ -24,10 +23,10 @@ pub trait MessageCallback {
     async fn custom_message(
         &self,
         handler: &MessageHandler,
-        relay: &MessageRelay<Message>,
+        ctx: &MessagePayload<Message>,
         msg: &MaybeEncrypted<CustomMessage>,
     );
-    async fn builtin_message(&self, handler: &MessageHandler, relay: &MessageRelay<Message>);
+    async fn builtin_message(&self, handler: &MessageHandler, ctx: &MessagePayload<Message>);
 }
 
 #[cfg(not(feature = "wasm"))]
@@ -41,6 +40,12 @@ pub struct MessageHandler {
     dht: Arc<Mutex<PeerRing>>,
     swarm: Arc<Swarm>,
     callback: Arc<Mutex<Option<CallbackFn>>>,
+}
+
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
+pub trait HandleMsg<T> {
+    async fn handle(&self, ctx: &MessagePayload<Message>, msg: &T) -> Result<()>;
 }
 
 impl MessageHandler {
@@ -69,41 +74,6 @@ impl MessageHandler {
         *cb = Some(f)
     }
 
-    pub async fn send_relay_message(&self, msg: MessageRelay<Message>) -> Result<()> {
-        #[cfg(test)]
-        {
-            println!("+++++++++++++++++++++++++++++++++");
-            println!("node {:?}", self.swarm.address());
-            println!("Sent {:?}", msg.clone());
-            println!("node {:?}", msg.next_hop);
-            println!("+++++++++++++++++++++++++++++++++");
-        }
-        if let Some(id) = msg.next_hop {
-            self.swarm.send_message(&id.into(), msg).await
-        } else {
-            Err(Error::NoNextHop)
-        }
-    }
-
-    pub async fn send_message(
-        &self,
-        next_hop: &Did,
-        destination: &Did,
-        msg: Message,
-    ) -> Result<()> {
-        self.send_relay_message(MessageRelay::new(
-            msg,
-            &self.swarm.session_manager,
-            OriginVerificationGen::Origin,
-            MessageRelayMethod::SEND,
-            None,
-            None,
-            Some(*next_hop),
-            *destination,
-        )?)
-        .await
-    }
-
     // disconnect a node if a node is in DHT
     pub async fn disconnect(&self, address: Address) {
         let mut dht = self.dht.lock().await;
@@ -124,30 +94,17 @@ impl MessageHandler {
             handshake_info: handshake_info.to_string(),
         });
         let next_hop = self.dht.lock().await.successor.max();
-        self.send_relay_message(MessageRelay::new(
-            connect_msg,
-            &self.swarm.session_manager,
-            OriginVerificationGen::Origin,
-            MessageRelayMethod::SEND,
-            None,
-            None,
-            Some(next_hop),
-            target_id,
-        )?)
-        .await?;
+        self.send_message(connect_msg, next_hop, target_id).await?;
         self.swarm.push_pending_transport(&transport)
     }
 
-    async fn invoke_callback(&self, relay: &MessageRelay<Message>) -> Result<()> {
+    async fn invoke_callback(&self, payload: &MessagePayload<Message>) -> Result<()> {
         let mut callback = self.callback.lock().await;
         if let Some(ref mut cb) = *callback {
-            let data = relay.data.clone();
+            let data = payload.data.clone();
             match data {
-                Message::None => {
-                    return Ok(());
-                }
-                Message::CustomMessage(msg) => cb.custom_message(self, relay, &msg).await,
-                _ => cb.builtin_message(self, relay).await,
+                Message::CustomMessage(msg) => cb.custom_message(self, payload, &msg).await,
+                _ => cb.builtin_message(self, payload).await,
             };
         }
         Ok(())
@@ -161,32 +118,28 @@ impl MessageHandler {
 
     #[cfg_attr(feature = "wasm", async_recursion(?Send))]
     #[cfg_attr(not(feature = "wasm"), async_recursion)]
-    pub async fn handle_message_relay(&self, relay: MessageRelay<Message>) -> Result<()> {
-        let data = relay.data.clone();
-        match data {
-            Message::JoinDHT(msg) => self.join_chord(relay.clone(), msg).await,
-            Message::ConnectNodeSend(msg) => self.connect_node(relay.clone(), msg).await,
-            Message::ConnectNodeReport(msg) => self.connected_node(relay.clone(), msg).await,
-            Message::AlreadyConnected(msg) => self.already_connected(relay.clone(), msg).await,
-            Message::FindSuccessorSend(msg) => self.find_successor(relay.clone(), msg).await,
-            Message::FindSuccessorReport(msg) => self.found_successor(relay.clone(), msg).await,
-            Message::NotifyPredecessorSend(msg) => {
-                self.notify_predecessor(relay.clone(), msg).await
-            }
-            Message::NotifyPredecessorReport(msg) => {
-                self.notified_predecessor(relay.clone(), msg).await
-            }
-            Message::SearchVNode(msg) => self.search_vnode(relay.clone(), msg).await,
-            Message::FoundVNode(msg) => self.found_vnode(relay.clone(), msg).await,
-            Message::StoreVNode(msg) => self.store_vnode(relay.clone(), msg).await,
-            Message::MultiCall(msg) => {
-                for message in msg.messages {
-                    let payload = relay.rewrap(
-                        message,
+    pub async fn handle_payload(&self, payload: &MessagePayload<Message>) -> Result<()> {
+        match &payload.data {
+            Message::JoinDHT(ref msg) => self.handle(payload, msg).await,
+            Message::ConnectNodeSend(ref msg) => self.handle(payload, msg).await,
+            Message::ConnectNodeReport(ref msg) => self.handle(payload, msg).await,
+            Message::AlreadyConnected(ref msg) => self.handle(payload, msg).await,
+            Message::FindSuccessorSend(ref msg) => self.handle(payload, msg).await,
+            Message::FindSuccessorReport(ref msg) => self.handle(payload, msg).await,
+            Message::NotifyPredecessorSend(ref msg) => self.handle(payload, msg).await,
+            Message::NotifyPredecessorReport(ref msg) => self.handle(payload, msg).await,
+            Message::SearchVNode(ref msg) => self.handle(payload, msg).await,
+            Message::FoundVNode(ref msg) => self.handle(payload, msg).await,
+            Message::StoreVNode(ref msg) => self.handle(payload, msg).await,
+            Message::MultiCall(ref msg) => {
+                for message in msg.messages.iter().cloned() {
+                    let payload = MessagePayload::new(
+                        message.clone(),
                         &self.swarm.session_manager,
-                        OriginVerificationGen::Stick(relay.origin_verification.clone()),
+                        OriginVerificationGen::Stick(payload.origin_verification.clone()),
+                        payload.relay.clone(),
                     )?;
-                    self.handle_message_relay(payload).await.unwrap_or(());
+                    self.handle_payload(&payload).await.unwrap_or(());
                 }
                 Ok(())
             }
@@ -196,7 +149,7 @@ impl MessageHandler {
                 x
             ))),
         }?;
-        if let Err(e) = self.invoke_callback(&relay).await {
+        if let Err(e) = self.invoke_callback(&payload).await {
             log::warn!("invoke callback error: {}", e);
         }
 
@@ -205,18 +158,38 @@ impl MessageHandler {
 
     /// This method is required because web-sys components is not `Send`
     /// which means a listening loop cannot running concurrency.
-    pub async fn listen_once(&self) -> Option<MessageRelay<Message>> {
-        if let Some(relay_message) = self.swarm.poll_message().await {
-            if !relay_message.verify() {
-                log::error!("Cannot verify msg or it's expired: {:?}", relay_message);
+    pub async fn listen_once(&self) -> Option<MessagePayload<Message>> {
+        if let Some(payload) = self.swarm.poll_message().await {
+            if !payload.verify() {
+                log::error!("Cannot verify msg or it's expired: {:?}", payload);
             }
-            if let Err(e) = self.handle_message_relay(relay_message.clone()).await {
+            if let Err(e) = self.handle_payload(&payload).await {
                 log::error!("Error in handle_message: {}", e);
             }
-            Some(relay_message)
+            Some(payload)
         } else {
             None
         }
+    }
+}
+
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
+impl PayloadSender<Message> for MessageHandler {
+    fn session_manager(&self) -> &SessionManager {
+        &self.swarm.session_manager
+    }
+
+    async fn do_send(&self, address: &Address, payload: MessagePayload<Message>) -> Result<()> {
+        #[cfg(test)]
+        {
+            println!("+++++++++++++++++++++++++++++++++");
+            println!("node {:?}", self.swarm.address());
+            println!("Sent {:?}", payload.clone());
+            println!("node {:?}", payload.relay.next_hop);
+            println!("+++++++++++++++++++++++++++++++++");
+        }
+        self.swarm.send_message(address, payload).await
     }
 }
 
@@ -233,14 +206,14 @@ mod listener {
     #[async_trait]
     impl MessageListener for MessageHandler {
         async fn listen(self: Arc<Self>) {
-            let relay_messages = self.swarm.iter_messages();
-            pin_mut!(relay_messages);
-            while let Some(relay_message) = relay_messages.next().await {
-                if relay_message.is_expired() || !relay_message.verify() {
-                    log::error!("Cannot verify msg or it's expired: {:?}", relay_message);
+            let payloads = self.swarm.iter_messages();
+            pin_mut!(payloads);
+            while let Some(payload) = payloads.next().await {
+                if !payload.verify() {
+                    log::error!("Cannot verify msg or it's expired: {:?}", payload);
                     continue;
                 }
-                if let Err(e) = self.handle_message_relay(relay_message).await {
+                if let Err(e) = self.handle_payload(&payload).await {
                     log::error!("Error in handle_message: {}", e);
                     continue;
                 }
@@ -367,22 +340,22 @@ pub mod test {
             async fn custom_message(
                 &self,
                 handler: &MessageHandler,
-                relay: &MessageRelay<Message>,
+                ctx: &MessagePayload<Message>,
                 msg: &MaybeEncrypted<CustomMessage>,
             ) {
                 let decrypted_msg = handler.decrypt_msg(msg).unwrap();
                 self.handler_messages
-                    .insert(relay.addr.into(), decrypted_msg.0);
+                    .insert(ctx.addr.into(), decrypted_msg.0);
 
-                println!("{:?}, {:?}, {:?}", relay, relay.addr, msg);
+                println!("{:?}, {:?}, {:?}", ctx, ctx.addr, msg);
             }
 
             async fn builtin_message(
                 &self,
                 _handler: &MessageHandler,
-                relay: &MessageRelay<Message>,
+                ctx: &MessagePayload<Message>,
             ) {
-                println!("{:?}, {:?}", relay, relay.addr);
+                println!("{:?}, {:?}", ctx, ctx.addr);
             }
         }
 
@@ -395,10 +368,9 @@ pub mod test {
         handler2.set_callback(cb2).await;
 
         handler1
-            .send_message(
-                &addr2.into(),
-                &addr2.into(),
+            .send_direct_message(
                 Message::custom("Hello world 1".as_bytes(), &None)?,
+                addr2.into(),
             )
             .await
             .unwrap();

--- a/rings-core/src/message/mod.rs
+++ b/rings-core/src/message/mod.rs
@@ -6,18 +6,18 @@ pub use encoder::Encoded;
 pub use encoder::Encoder;
 
 mod payload;
-pub use payload::MessageRelay;
-pub use payload::MessageRelayMethod;
+pub use payload::MessagePayload;
 pub use payload::OriginVerificationGen;
-
-mod protocol;
-pub use protocol::MessageSessionRelayProtocol;
+pub use payload::PayloadSender;
 
 mod types;
 pub use types::*;
 
 pub mod handlers;
-pub use handlers::connection::TChordConnection;
-pub use handlers::storage::TChordStorage;
+pub use handlers::HandleMsg;
 pub use handlers::MessageCallback;
 pub use handlers::MessageHandler;
+
+mod protocols;
+pub use protocols::MessageRelay;
+pub use protocols::RelayMethod;

--- a/rings-core/src/message/payload.rs
+++ b/rings-core/src/message/payload.rs
@@ -1,11 +1,11 @@
 use super::encoder::{Decoder, Encoded, Encoder};
+use super::protocols::{MessageRelay, MessageVerification, RelayMethod};
 use crate::dht::Did;
-use crate::ecc::{signers, HashStr, PublicKey};
+use crate::ecc::{HashStr, PublicKey};
 use crate::err::{Error, Result};
-use crate::message::protocol::MessageSessionRelayProtocol;
 use crate::session::SessionManager;
-use crate::session::{Session, Signer};
 use crate::utils;
+use async_trait::async_trait;
 use flate2::write::{GzDecoder, GzEncoder};
 use flate2::Compression;
 use serde::de::DeserializeOwned;
@@ -16,114 +16,37 @@ use web3::types::Address;
 
 const DEFAULT_TTL_MS: usize = 60 * 1000;
 
-#[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
-pub enum MessageRelayMethod {
-    SEND,
-    REPORT,
-}
-
 pub enum OriginVerificationGen {
     Origin,
     Stick(MessageVerification),
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
-pub struct MessageVerification {
-    pub session: Session,
-    pub ttl_ms: usize,
-    pub ts_ms: u128,
-    pub sig: Vec<u8>,
-}
-
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
-pub struct MessageRelay<T> {
+pub struct MessagePayload<T> {
     pub data: T,
     pub tx_id: HashStr,
     pub addr: Address,
-
-    // verification
-    pub relay_verification: MessageVerification,
+    pub verification: MessageVerification,
     pub origin_verification: MessageVerification,
-
-    // relay
-    pub method: MessageRelayMethod,
-    pub path: Vec<Did>,
-    pub path_end_cursor: usize,
-    pub next_hop: Option<Did>,
-    pub destination: Did,
+    pub relay: MessageRelay,
 }
 
-impl MessageVerification {
-    pub fn verify<T>(&self, data: &T) -> bool
-    where
-        T: Serialize,
-    {
-        if !self.session.verify() {
-            return false;
-        }
-
-        if let (Ok(addr), Ok(msg)) = (self.session.address(), self.msg(data)) {
-            match self.session.auth.signer {
-                Signer::DEFAULT => signers::default::verify(&msg, &addr, &self.sig),
-                Signer::EIP712 => signers::eip712::verify(&msg, &addr, &self.sig),
-            }
-        } else {
-            false
-        }
-    }
-
-    pub fn session_pubkey<T>(&self, data: &T) -> Result<PublicKey>
-    where
-        T: Serialize,
-    {
-        let msg = self.msg(data)?;
-        match self.session.auth.signer {
-            Signer::DEFAULT => signers::default::recover(&msg, &self.sig),
-            Signer::EIP712 => signers::eip712::recover(&msg, &self.sig),
-        }
-    }
-
-    pub fn pack_msg<T>(data: &T, ts_ms: u128, ttl_ms: usize) -> Result<String>
-    where
-        T: Serialize,
-    {
-        let mut msg = serde_json::to_string(data).map_err(|_| Error::SerializeToString)?;
-        msg.push_str(&format!("\n{}\n{}", ts_ms, ttl_ms));
-        Ok(msg)
-    }
-
-    fn msg<T>(&self, data: &T) -> Result<String>
-    where
-        T: Serialize,
-    {
-        Self::pack_msg(data, self.ts_ms, self.ttl_ms)
-    }
-}
-
-impl<T> MessageRelay<T>
+impl<T> MessagePayload<T>
 where
     T: Serialize + DeserializeOwned,
 {
-    // TODO: split verification and relay out
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         data: T,
         session_manager: &SessionManager,
         origin_verification_gen: OriginVerificationGen,
-        method: MessageRelayMethod,
-        path: Option<Vec<Did>>,
-        path_end_cursor: Option<usize>,
-        next_hop: Option<Did>,
-        destination: Did,
+        relay: MessageRelay,
     ) -> Result<Self> {
         let ts_ms = utils::get_epoch_ms();
         let ttl_ms = DEFAULT_TTL_MS;
         let msg = &MessageVerification::pack_msg(&data, ts_ms, ttl_ms)?;
         let tx_id = msg.into();
-        let addr = session_manager.authorizer()?.to_owned();
-        let path = path.unwrap_or_else(|| vec![addr.into()]);
-        let path_end_cursor = path_end_cursor.unwrap_or(0);
-        let relay_verification = MessageVerification {
+        let addr = session_manager.authorizer()?;
+        let verification = MessageVerification {
             session: session_manager.session()?,
             sig: session_manager.sign(msg)?,
             ttl_ms,
@@ -131,79 +54,52 @@ where
         };
 
         let origin_verification = match origin_verification_gen {
-            OriginVerificationGen::Origin => relay_verification.clone(),
+            OriginVerificationGen::Origin => verification.clone(),
             OriginVerificationGen::Stick(ov) => ov,
         };
 
         Ok(Self {
             data,
-            addr,
             tx_id,
-            relay_verification,
+            addr,
+            verification,
             origin_verification,
-            method,
-            path,
-            path_end_cursor,
-            next_hop,
-            destination,
+            relay,
         })
     }
 
-    pub fn direct(data: T, session_manager: &SessionManager, dist: Did) -> Result<Self> {
-        Self::new(
-            data,
-            session_manager,
-            OriginVerificationGen::Origin,
-            MessageRelayMethod::SEND,
-            None,
-            None,
-            Some(dist),
-            dist,
-        )
-    }
-
-    pub fn rewrap(
-        &self,
+    pub fn new_send(
         data: T,
         session_manager: &SessionManager,
-        origin_verification_gen: OriginVerificationGen,
+        next_hop: Did,
+        destination: Did,
     ) -> Result<Self> {
-        Self::new(
-            data,
-            session_manager,
-            origin_verification_gen,
-            self.method.clone(),
-            Some(self.path.clone()),
-            Some(self.path_end_cursor),
-            self.next_hop,
-            self.destination,
-        )
+        let relay = MessageRelay::new(
+            RelayMethod::SEND,
+            vec![session_manager.authorizer()?.into()],
+            None,
+            Some(next_hop),
+            destination,
+        );
+        Self::new(data, session_manager, OriginVerificationGen::Origin, relay)
     }
 
-    pub fn report(&self, data: T, session_manager: &SessionManager) -> Result<Self> {
-        if self.method != MessageRelayMethod::SEND {
-            return Err(Error::ReportNeedSend);
-        }
+    pub fn new_report(
+        data: T,
+        session_manager: &SessionManager,
+        relay: &MessageRelay,
+    ) -> Result<Self> {
+        let relay = relay.report()?;
+        Self::new(data, session_manager, OriginVerificationGen::Origin, relay)
+    }
 
-        if self.path.len() < 2 {
-            return Err(Error::CannotInferNextHop);
-        }
-
-        Self::new(
-            data,
-            session_manager,
-            OriginVerificationGen::Origin,
-            MessageRelayMethod::REPORT,
-            Some(self.path.clone()),
-            Some(self.path_end_cursor),
-            self.path_prev(),
-            self.sender(),
-        )
+    pub fn new_direct(data: T, session_manager: &SessionManager, destination: Did) -> Result<Self> {
+        Self::new_send(data, session_manager, destination, destination)
     }
 
     pub fn is_expired(&self) -> bool {
         let now = utils::get_epoch_ms();
-        now > self.relay_verification.ts_ms + self.relay_verification.ttl_ms as u128
+        now > self.verification.ts_ms + self.verification.ttl_ms as u128
             && now > self.origin_verification.ts_ms + self.origin_verification.ttl_ms as u128
     }
 
@@ -212,7 +108,7 @@ where
             return false;
         }
 
-        self.relay_verification.verify(&self.data) && self.origin_verification.verify(&self.data)
+        self.verification.verify(&self.data) && self.origin_verification.verify(&self.data)
     }
 
     pub fn origin_session_pubkey(&self) -> Result<PublicKey> {
@@ -256,7 +152,7 @@ where
     }
 }
 
-impl<T> Encoder for MessageRelay<T>
+impl<T> Encoder for MessagePayload<T>
 where
     T: Serialize + DeserializeOwned,
 {
@@ -265,13 +161,73 @@ where
     }
 }
 
-impl<T> Decoder for MessageRelay<T>
+impl<T> Decoder for MessagePayload<T>
 where
     T: Serialize + DeserializeOwned,
 {
     fn from_encoded(encoded: &Encoded) -> Result<Self> {
         let v: Vec<u8> = encoded.decode()?;
         Self::from_auto(&v)
+    }
+}
+
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
+pub trait PayloadSender<T>
+where
+    T: Clone + Serialize + DeserializeOwned + Send + Sync + 'static,
+{
+    fn session_manager(&self) -> &SessionManager;
+    async fn do_send(&self, address: &Address, payload: MessagePayload<T>) -> Result<()>;
+
+    async fn send_payload(&self, payload: MessagePayload<T>) -> Result<()> {
+        if let Some(id) = payload.relay.next_hop {
+            self.do_send(&id.into(), payload).await
+        } else {
+            Err(Error::NoNextHop)
+        }
+    }
+
+    async fn send_message(&self, msg: T, next_hop: Did, destination: Did) -> Result<()> {
+        self.send_payload(MessagePayload::new_send(
+            msg,
+            self.session_manager(),
+            next_hop,
+            destination,
+        )?)
+        .await
+    }
+
+    async fn send_direct_message(&self, msg: T, destination: Did) -> Result<()> {
+        self.send_payload(MessagePayload::new_direct(
+            msg,
+            self.session_manager(),
+            destination,
+        )?)
+        .await
+    }
+
+    async fn send_report_message(&self, msg: T, relay: MessageRelay) -> Result<()> {
+        self.send_payload(MessagePayload::new_report(
+            msg,
+            self.session_manager(),
+            &relay,
+        )?)
+        .await
+    }
+
+    async fn transpond_payload(
+        &self,
+        payload: &MessagePayload<T>,
+        relay: MessageRelay,
+    ) -> Result<()> {
+        self.send_payload(MessagePayload::new(
+            payload.data.clone(),
+            self.session_manager(),
+            OriginVerificationGen::Stick(payload.origin_verification.clone()),
+            relay,
+        )?)
+        .await
     }
 }
 
@@ -288,7 +244,7 @@ pub mod test {
         d: bool,
     }
 
-    pub fn new_test_message() -> MessageRelay<TestData> {
+    pub fn new_test_payload() -> MessagePayload<TestData> {
         let key = SecretKey::random();
         let destination = SecretKey::random().address().into();
         let session = SessionManager::new_with_seckey(&key).unwrap();
@@ -298,30 +254,20 @@ pub mod test {
             c: 2.33,
             d: true,
         };
-        MessageRelay::new(
-            test_data,
-            &session,
-            OriginVerificationGen::Origin,
-            MessageRelayMethod::SEND,
-            None,
-            None,
-            None,
-            destination,
-        )
-        .unwrap()
+        MessagePayload::direct(test_data, &session, destination).unwrap()
     }
 
     #[test]
     fn new_then_verify() {
-        let mut payload = new_test_message();
+        let mut payload = new_test_payload();
         assert!(payload.verify());
 
         let key2 = SecretKey::random();
         let did2 = key2.address().into();
         let session2 = SessionManager::new_with_seckey(&key2).unwrap();
 
-        payload.next_hop = Some(did2);
-        payload.relay(did2, None).unwrap();
+        payload.relay.next_hop = Some(did2);
+        payload.relay.relay(did2, None).unwrap();
 
         let relaied_payload = payload
             .rewrap(
@@ -336,21 +282,21 @@ pub mod test {
 
     #[test]
     fn test_message_relay_gzip() {
-        let payload = new_test_message();
+        let payload = new_test_payload();
         let gziped = payload.gzip(9).unwrap();
-        let payload2: MessageRelay<TestData> = MessageRelay::from_gzipped(&gziped).unwrap();
+        let payload2: MessagePayload<TestData> = MessagePayload::from_gzipped(&gziped).unwrap();
         assert_eq!(payload, payload2);
     }
 
     #[test]
     fn test_message_relay_from_auto() {
-        let payload = new_test_message();
+        let payload = new_test_payload();
         let gziped_encoded_payload = payload.encode().unwrap();
-        let payload2: MessageRelay<TestData> = gziped_encoded_payload.decode().unwrap();
+        let payload2: MessagePayload<TestData> = gziped_encoded_payload.decode().unwrap();
         assert_eq!(payload, payload2);
 
         let ungzip_encoded_payload = payload.to_json_vec().unwrap().encode().unwrap();
-        let payload2: MessageRelay<TestData> = ungzip_encoded_payload.decode().unwrap();
+        let payload2: MessagePayload<TestData> = ungzip_encoded_payload.decode().unwrap();
         assert_eq!(payload, payload2);
     }
 }

--- a/rings-core/src/message/protocols/mod.rs
+++ b/rings-core/src/message/protocols/mod.rs
@@ -1,0 +1,5 @@
+mod relay;
+mod verify;
+
+pub use self::relay::{MessageRelay, RelayMethod};
+pub use self::verify::MessageVerification;

--- a/rings-core/src/message/protocols/relay.rs
+++ b/rings-core/src/message/protocols/relay.rs
@@ -32,39 +32,45 @@
 
 #![warn(missing_docs)]
 
-use super::payload::MessageRelay;
-use super::payload::MessageRelayMethod;
 use crate::dht::Did;
 use crate::err::{Error, Result};
+use serde::Deserialize;
+use serde::Serialize;
 
-/// MessageSessionRelayProtocol guide message passing on rings network by relay.
-pub trait MessageSessionRelayProtocol {
-    /// Check current did, update path and its end cursor, then infer next_hop.
-    fn relay(&mut self, current: Did, next_hop: Option<Did>) -> Result<()>;
-
-    /// A SEND message can change its destination.
-    /// Call with REPORT method will get an error imeediately.
-    fn reset_destination(&mut self, destination: Did) -> Result<()>;
-
-    /// Check if path and destination is valid.
-    /// It will be automatically called at relay started.
-    fn validate(&self) -> Result<()>;
-
-    /// Get sender of current message.
-    /// With SEND method, it will be the `origin()` of the message.
-    /// With REPORT method, it will be the last element of path.
-    fn sender(&self) -> Did;
-
-    /// Get the original sender of current message.
-    /// Should always be the first element of path.
-    fn origin(&self) -> Did;
-
-    /// Get the previous element of the element pointed by path_end_cursor.
-    fn path_prev(&self) -> Option<Did>;
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+pub enum RelayMethod {
+    SEND,
+    REPORT,
 }
 
-impl<T> MessageSessionRelayProtocol for MessageRelay<T> {
-    fn relay(&mut self, current: Did, next_hop: Option<Did>) -> Result<()> {
+/// MessageRelay guide message passing on rings network by relay.
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+pub struct MessageRelay {
+    pub method: RelayMethod,
+    pub path: Vec<Did>,
+    pub path_end_cursor: usize,
+    pub next_hop: Option<Did>,
+    pub destination: Did,
+}
+
+impl MessageRelay {
+    pub fn new(
+        method: RelayMethod,
+        path: Vec<Did>,
+        path_end_cursor: Option<usize>,
+        next_hop: Option<Did>,
+        destination: Did,
+    ) -> Self {
+        Self {
+            method,
+            path,
+            path_end_cursor: path_end_cursor.unwrap_or(0),
+            next_hop,
+            destination,
+        }
+    }
+    /// Check current did, update path and its end cursor, then infer next_hop.
+    pub fn relay(&mut self, current: Did, next_hop: Option<Did>) -> Result<()> {
         self.validate()?;
 
         // If self.next_hop is setted, it should be current
@@ -73,13 +79,13 @@ impl<T> MessageSessionRelayProtocol for MessageRelay<T> {
         }
 
         match self.method {
-            MessageRelayMethod::SEND => {
+            RelayMethod::SEND => {
                 self.path.push(current);
                 self.next_hop = next_hop;
                 Ok(())
             }
 
-            MessageRelayMethod::REPORT => {
+            RelayMethod::REPORT => {
                 // The final hop
                 if self.next_hop == Some(self.destination) {
                     self.path_end_cursor = self.path.len() - 1;
@@ -110,8 +116,28 @@ impl<T> MessageSessionRelayProtocol for MessageRelay<T> {
         }
     }
 
-    fn reset_destination(&mut self, destination: Did) -> Result<()> {
-        if self.method == MessageRelayMethod::SEND {
+    pub fn report(&self) -> Result<Self> {
+        if self.method != RelayMethod::SEND {
+            return Err(Error::ReportNeedSend);
+        }
+
+        if self.path.len() < 2 {
+            return Err(Error::CannotInferNextHop);
+        }
+
+        Ok(Self {
+            method: RelayMethod::REPORT,
+            path: self.path.clone(),
+            path_end_cursor: 0,
+            next_hop: self.path_prev(),
+            destination: self.sender(),
+        })
+    }
+
+    /// A SEND message can change its destination.
+    /// Call with REPORT method will get an error imeediately.
+    pub fn reset_destination(&mut self, destination: Did) -> Result<()> {
+        if self.method == RelayMethod::SEND {
             self.destination = destination;
             Ok(())
         } else {
@@ -119,32 +145,40 @@ impl<T> MessageSessionRelayProtocol for MessageRelay<T> {
         }
     }
 
-    fn validate(&self) -> Result<()> {
+    /// Check if path and destination is valid.
+    /// It will be automatically called at relay started.
+    pub fn validate(&self) -> Result<()> {
         // Adjacent elements in self.path cannot be equal
         if self.path.windows(2).any(|w| w[0] == w[1]) {
             return Err(Error::InvalidRelayPath);
         }
 
         // The destination of report message should always be the first element of path
-        if self.method == MessageRelayMethod::REPORT && self.path[0] != self.destination {
+        if self.method == RelayMethod::REPORT && self.path[0] != self.destination {
             return Err(Error::InvalidRelayDestination);
         }
 
         Ok(())
     }
 
-    fn origin(&self) -> Did {
+    /// Get sender of current message.
+    /// With SEND method, it will be the `origin()` of the message.
+    /// With REPORT method, it will be the last element of path.
+    pub fn origin(&self) -> Did {
         *self.path.first().unwrap()
     }
 
-    fn sender(&self) -> Did {
+    /// Get the original sender of current message.
+    /// Should always be the first element of path.
+    pub fn sender(&self) -> Did {
         match self.method {
-            MessageRelayMethod::SEND => self.origin(),
-            MessageRelayMethod::REPORT => *self.path.last().unwrap(),
+            RelayMethod::SEND => self.origin(),
+            RelayMethod::REPORT => *self.path.last().unwrap(),
         }
     }
 
-    fn path_prev(&self) -> Option<Did> {
+    /// Get the previous element of the element pointed by path_end_cursor.
+    pub fn path_prev(&self) -> Option<Did> {
         if self.path.len() < self.path_end_cursor + 2 {
             None
         } else {
@@ -157,59 +191,67 @@ impl<T> MessageSessionRelayProtocol for MessageRelay<T> {
 mod test {
     use super::*;
     use crate::ecc::SecretKey;
-    use crate::message::payload::test::new_test_message;
-    use crate::session::SessionManager;
 
     #[test]
     fn test_path_end_cursor() {
-        let mut send_payload = new_test_message();
+        let origin_sender = SecretKey::random().address().into();
         let next_hop1 = SecretKey::random().address().into();
         let next_hop2 = SecretKey::random().address().into();
         let next_hop3 = SecretKey::random().address().into();
 
+        let mut send_relay = MessageRelay {
+            method: RelayMethod::SEND,
+            path: vec![origin_sender],
+            path_end_cursor: 0,
+            next_hop: None,
+            destination: next_hop3,
+        };
+
         // node0 -> node1
-        send_payload.relay(next_hop1, None).unwrap();
-        assert_eq!(send_payload.path_end_cursor, 0);
+        send_relay.relay(next_hop1, None).unwrap();
+        assert_eq!(send_relay.path_end_cursor, 0);
 
         // node0 -> node1 -> node2
-        send_payload.relay(next_hop2, None).unwrap();
-        assert_eq!(send_payload.path_end_cursor, 0);
+        send_relay.relay(next_hop2, None).unwrap();
+        assert_eq!(send_relay.path_end_cursor, 0);
 
         // node0 -> node1 -> node2 -> node3
-        send_payload.relay(next_hop3, None).unwrap();
-        assert_eq!(send_payload.path_end_cursor, 0);
+        send_relay.relay(next_hop3, None).unwrap();
+        assert_eq!(send_relay.path_end_cursor, 0);
 
         // node3 make REPORT, destination is node0
-        let fake_session = SessionManager::new_with_seckey(&SecretKey::random()).unwrap();
-        let mut report_payload = send_payload
-            .report(send_payload.data.clone(), &fake_session)
-            .unwrap();
-        assert_eq!(report_payload.path_end_cursor, 0);
+        let mut report_relay = send_relay.report().unwrap();
+        assert_eq!(report_relay.path_end_cursor, 0);
 
         // node0 -> node1 -> node2 -> node3 -> node2
-        report_payload.relay(next_hop2, None).unwrap();
-        assert_eq!(report_payload.path_end_cursor, 1);
+        report_relay.relay(next_hop2, None).unwrap();
+        assert_eq!(report_relay.path_end_cursor, 1);
 
         // node0 -> node1 -> node2 -> node3 -> node2 -> node1
-        report_payload.relay(next_hop1, None).unwrap();
-        assert_eq!(report_payload.path_end_cursor, 2);
+        report_relay.relay(next_hop1, None).unwrap();
+        assert_eq!(report_relay.path_end_cursor, 2);
     }
 
     #[test]
     fn test_path_prev() {
-        let mut payload = new_test_message();
-        let fake_id = SecretKey::random().address().into();
+        let origin_sender = SecretKey::random().address().into();
         let next_hop1 = SecretKey::random().address().into();
         let next_hop2 = SecretKey::random().address().into();
 
-        assert!(payload.path_prev().is_none());
+        let mut relay = MessageRelay {
+            method: RelayMethod::SEND,
+            path: vec![origin_sender],
+            path_end_cursor: 0,
+            next_hop: None,
+            destination: next_hop2,
+        };
 
-        payload.path[0] = fake_id;
+        assert!(relay.path_prev().is_none());
 
-        payload.relay(next_hop1, None).unwrap();
-        assert_eq!(payload.path_prev(), Some(fake_id));
+        relay.relay(next_hop1, None).unwrap();
+        assert_eq!(relay.path_prev(), Some(origin_sender));
 
-        payload.relay(next_hop2, None).unwrap();
-        assert_eq!(payload.path_prev(), Some(next_hop1));
+        relay.relay(next_hop2, None).unwrap();
+        assert_eq!(relay.path_prev(), Some(next_hop1));
     }
 }

--- a/rings-core/src/message/protocols/verify.rs
+++ b/rings-core/src/message/protocols/verify.rs
@@ -1,0 +1,60 @@
+use crate::ecc::{signers, PublicKey};
+use crate::err::{Error, Result};
+use crate::session::{Session, Signer};
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+pub struct MessageVerification {
+    pub session: Session,
+    pub ttl_ms: usize,
+    pub ts_ms: u128,
+    pub sig: Vec<u8>,
+}
+
+impl MessageVerification {
+    pub fn verify<T>(&self, data: &T) -> bool
+    where
+        T: Serialize,
+    {
+        if !self.session.verify() {
+            return false;
+        }
+
+        if let (Ok(addr), Ok(msg)) = (self.session.address(), self.msg(data)) {
+            match self.session.auth.signer {
+                Signer::DEFAULT => signers::default::verify(&msg, &addr, &self.sig),
+                Signer::EIP712 => signers::eip712::verify(&msg, &addr, &self.sig),
+            }
+        } else {
+            false
+        }
+    }
+
+    pub fn session_pubkey<T>(&self, data: &T) -> Result<PublicKey>
+    where
+        T: Serialize,
+    {
+        let msg = self.msg(data)?;
+        match self.session.auth.signer {
+            Signer::DEFAULT => signers::default::recover(&msg, &self.sig),
+            Signer::EIP712 => signers::eip712::recover(&msg, &self.sig),
+        }
+    }
+
+    pub fn pack_msg<T>(data: &T, ts_ms: u128, ttl_ms: usize) -> Result<String>
+    where
+        T: Serialize,
+    {
+        let mut msg = serde_json::to_string(data).map_err(|_| Error::SerializeToString)?;
+        msg.push_str(&format!("\n{}\n{}", ts_ms, ttl_ms));
+        Ok(msg)
+    }
+
+    fn msg<T>(&self, data: &T) -> Result<String>
+    where
+        T: Serialize,
+    {
+        Self::pack_msg(data, self.ts_ms, self.ttl_ms)
+    }
+}

--- a/rings-core/src/message/types.rs
+++ b/rings-core/src/message/types.rs
@@ -94,7 +94,6 @@ pub enum MaybeEncrypted<T> {
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub enum Message {
-    None,
     MultiCall(MultiCall),
     JoinDHT(JoinDHT),
     LeaveDHT(LeaveDHT),

--- a/rings-core/src/session.rs
+++ b/rings-core/src/session.rs
@@ -10,7 +10,6 @@ use crate::ecc::PublicKey;
 use crate::ecc::SecretKey;
 use crate::err::{Error, Result};
 use crate::utils;
-use dashmap::DashMap;
 use serde::Deserialize;
 use serde::Serialize;
 use std::sync::Arc;
@@ -56,14 +55,12 @@ pub struct SessionWithKey {
 #[derive(Debug)]
 pub struct SessionManager {
     inner: Arc<RwLock<SessionWithKey>>,
-    remote_sessions: Arc<DashMap<Address, (Session, PublicKey)>>,
 }
 
 impl Clone for SessionManager {
     fn clone(&self) -> Self {
         Self {
             inner: Arc::clone(&self.inner),
-            remote_sessions: Arc::clone(&self.remote_sessions),
         }
     }
 }
@@ -155,7 +152,6 @@ impl SessionManager {
 
         Self {
             inner: Arc::new(RwLock::new(inner)),
-            remote_sessions: Arc::new(DashMap::new()),
         }
     }
 

--- a/rings-core/src/transports/default/transport.rs
+++ b/rings-core/src/transports/default/transport.rs
@@ -1,9 +1,7 @@
 use crate::channels::Channel as AcChannel;
 use crate::ecc::PublicKey;
 use crate::err::{Error, Result};
-use crate::message::MessageRelayMethod;
-use crate::message::{Encoded, Encoder};
-use crate::message::{MessageRelay, OriginVerificationGen};
+use crate::message::{Encoded, Encoder, MessagePayload};
 use crate::session::SessionManager;
 use crate::transports::helper::Promise;
 use crate::transports::helper::TricklePayload;
@@ -410,21 +408,16 @@ impl IceTrickleScheme<Event, AcChannel<Event>> for DefaultTransport {
             candidates: local_candidates_json,
         };
         log::trace!("prepared hanshake info :{:?}", data);
-        let resp = MessageRelay::new(
+        let resp = MessagePayload::new_direct(
             data,
             session_manager,
-            OriginVerificationGen::Origin,
-            MessageRelayMethod::SEND,
-            None,
-            None,
-            None,
             session_manager.authorizer()?.to_owned().into(), // This is a fake destination
         )?;
         Ok(resp.gzip(9)?.encode()?)
     }
 
     async fn register_remote_info(&self, data: Encoded) -> Result<Address> {
-        let data: MessageRelay<TricklePayload> = data.decode()?;
+        let data: MessagePayload<TricklePayload> = data.decode()?;
         log::trace!("register remote info: {:?}", data);
         match data.verify() {
             true => {

--- a/rings-core/src/transports/wasm/transport.rs
+++ b/rings-core/src/transports/wasm/transport.rs
@@ -2,9 +2,7 @@ use super::helper::RtcSessionDescriptionWrapper;
 use crate::channels::Channel as CbChannel;
 use crate::ecc::PublicKey;
 use crate::err::{Error, Result};
-use crate::message::MessageRelayMethod;
-use crate::message::{Encoded, Encoder};
-use crate::message::{MessageRelay, OriginVerificationGen};
+use crate::message::{Encoded, Encoder, MessagePayload};
 use crate::session::SessionManager;
 use crate::transports::helper::Promise;
 use crate::transports::helper::TricklePayload;
@@ -438,21 +436,16 @@ impl IceTrickleScheme<Event, CbChannel<Event>> for WasmTransport {
             candidates: local_candidates_json,
         };
         log::debug!("prepared hanshake info :{:?}", data);
-        let resp = MessageRelay::new(
+        let resp = MessagePayload::new_direct(
             data,
             session_manager,
-            OriginVerificationGen::Origin,
-            MessageRelayMethod::SEND,
-            None,
-            None,
-            None,
             session_manager.authorizer()?.to_owned().into(), // This is a fake destination
         )?;
         Ok(resp.gzip(9)?.encode()?)
     }
 
     async fn register_remote_info(&self, data: Encoded) -> Result<Address> {
-        let data: MessageRelay<TricklePayload> = data.decode()?;
+        let data: MessagePayload<TricklePayload> = data.decode()?;
         log::debug!("register remote info: {:?}", &data);
 
         match data.verify() {

--- a/rings-core/tests/default/test_message_handler.rs
+++ b/rings-core/tests/default/test_message_handler.rs
@@ -136,7 +136,7 @@ pub mod test {
                 unreachable!();
             }
         };
-        match handle1.handle_message_relay(relay_message).await {
+        match handle1.handle_payload(relay_message).await {
             Ok(_) => assert_eq!(true, true),
             Err(e) => {
                 println!("{:?}", e);

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -9,7 +9,7 @@ use crate::{
         ecc::SecretKey,
         message::{
             CustomMessage, Encoded, MaybeEncrypted, Message, MessageCallback, MessageHandler,
-            MessageRelay,
+            MessagePayload,
         },
         prelude::web3::types::Address,
         session::SessionManager,
@@ -326,7 +326,7 @@ impl MessageCallback for MessageCallbackInstance {
     async fn custom_message(
         &self,
         handler: &MessageHandler,
-        relay: &MessageRelay<Message>,
+        relay: &MessagePayload<Message>,
         msg: &MaybeEncrypted<CustomMessage>,
     ) {
         log::debug!("custom_message received: {:?}", msg);
@@ -354,7 +354,7 @@ impl MessageCallback for MessageCallbackInstance {
         //let a = wasm_bindgen_futures::JsFuture::from(self.on_cutom_message.as_ref().clone()).await;
     }
 
-    async fn builtin_message(&self, _handler: &MessageHandler, relay: &MessageRelay<Message>) {
+    async fn builtin_message(&self, _handler: &MessageHandler, relay: &MessagePayload<Message>) {
         let this = JsValue::null();
         log::debug!("builtin_message received: {:?}", relay);
         if let Ok(r) = self

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,7 +43,7 @@ pub enum Error {
     #[error("Send mesage error: {0}")]
     SendMessage(rings_core::err::Error),
     #[error("Build message body error: {0}")]
-    MessageRelay(rings_core::err::Error),
+    MessagePayload(rings_core::err::Error),
 }
 
 impl Error {
@@ -68,7 +68,7 @@ impl Error {
             Error::ConnectWithAddressError(_) => 16,
             Error::ConnectError(_) => 17,
             Error::SendMessage(_) => 18,
-            Error::MessageRelay(_) => 19,
+            Error::MessagePayload(_) => 19,
         };
         -32000 - code
     }

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -5,7 +5,7 @@ use crate::{
     jsonrpc::{method, response::TransportAndIce},
     jsonrpc_client::SimpleClient,
     prelude::rings_core::{
-        message::{Encoded, Message, MessageHandler},
+        message::{Encoded, Message, MessageHandler, PayloadSender},
         prelude::{
             uuid,
             web3::{contract::tokens::Tokenizable, ethabi::Token, types::Address},
@@ -301,7 +301,7 @@ impl Processor {
         let destination = Address::from_str(destination).map_err(|_| Error::InvalidAddress)?;
         let msg = Message::custom(msg, &None).map_err(Error::SendMessage)?;
         self.msg_handler
-            .send_message(&next_hop.into(), &destination.into(), msg)
+            .send_message(msg, next_hop.into(), destination.into())
             .await
             .map_err(Error::SendMessage)?;
         Ok(())


### PR DESCRIPTION
- Rename `MessageRelay` to `MessagePayload`. 
- `MessageRelay` is now an independent struct for handling relay protocol in `message.protocols` module.
- Split verification and relay fields of `MessagePayload` to `message.protocols` module.
- Add some construct functions on `MessagePayload` and `MessageRelay`.
- Add two traits `PayloadSender` and `HandleMsg`.
- Implement those two traits for `MessageHandler`.