### PR TITLE
config rust fmt

### DIFF
--- a/bin/daemon.rs
+++ b/bin/daemon.rs
@@ -1,26 +1,34 @@
-use clap::{Args, Parser, Subcommand};
+use std::fs::File;
+use std::fs::{self};
+use std::str::FromStr;
+use std::str::{self};
+use std::sync::Arc;
+
+use clap::Args;
+use clap::Parser;
+use clap::Subcommand;
 use daemonize::Daemonize;
 use futures::lock::Mutex;
 use libc::kill;
-use rings_node::{
-    logger::{LogLevel, Logger},
-    prelude::rings_core::{
-        async_trait,
-        dht::{PeerRing, Stabilization, TStabilize},
-        ecc::SecretKey,
-        message::{self, CustomMessage, MaybeEncrypted, Message, MessageHandler, MessagePayload},
-        prelude::url,
-        session::SessionManager,
-        swarm::Swarm,
-        types::message::MessageListener,
-    },
-    service::{run_service, run_udp_turn},
-};
-use std::{
-    fs::{self, File},
-    str::{self, FromStr},
-    sync::Arc,
-};
+use rings_node::logger::LogLevel;
+use rings_node::logger::Logger;
+use rings_node::prelude::rings_core::async_trait;
+use rings_node::prelude::rings_core::dht::PeerRing;
+use rings_node::prelude::rings_core::dht::Stabilization;
+use rings_node::prelude::rings_core::dht::TStabilize;
+use rings_node::prelude::rings_core::ecc::SecretKey;
+use rings_node::prelude::rings_core::message::CustomMessage;
+use rings_node::prelude::rings_core::message::MaybeEncrypted;
+use rings_node::prelude::rings_core::message::Message;
+use rings_node::prelude::rings_core::message::MessageHandler;
+use rings_node::prelude::rings_core::message::MessagePayload;
+use rings_node::prelude::rings_core::message::{self};
+use rings_node::prelude::rings_core::prelude::url;
+use rings_node::prelude::rings_core::session::SessionManager;
+use rings_node::prelude::rings_core::swarm::Swarm;
+use rings_node::prelude::rings_core::types::message::MessageListener;
+use rings_node::service::run_service;
+use rings_node::service::run_udp_turn;
 use tokio::signal;
 
 #[derive(Parser, Debug)]

--- a/bin/main.rs
+++ b/bin/main.rs
@@ -1,8 +1,13 @@
 #![feature(async_closure)]
-use clap::{Args, Parser, Subcommand};
+use std::sync::Arc;
+
+use clap::Args;
+use clap::Parser;
+use clap::Subcommand;
 use futures::lock::Mutex;
 use rings_core::dht::PeerRing;
-use rings_core::dht::{Stabilization, TStabilize};
+use rings_core::dht::Stabilization;
+use rings_core::dht::TStabilize;
 use rings_core::ecc::SecretKey;
 use rings_core::message::MessageHandler;
 use rings_core::session::SessionManager;
@@ -12,7 +17,6 @@ use rings_node::cli::Client;
 use rings_node::logger::LogLevel;
 use rings_node::logger::Logger;
 use rings_node::service::run_service;
-use std::sync::Arc;
 
 #[derive(Parser, Debug)]
 #[clap(about, version, author)]

--- a/rings-core/src/channels/default.rs
+++ b/rings-core/src/channels/default.rs
@@ -1,9 +1,11 @@
-use crate::err::{Error, Result};
-use crate::types::channel::Channel;
 use async_channel as ac;
 use async_channel::Receiver;
 use async_channel::Sender;
 use async_trait::async_trait;
+
+use crate::err::Error;
+use crate::err::Result;
+use crate::types::channel::Channel;
 
 pub struct AcChannel<T> {
     sender: Sender<T>,

--- a/rings-core/src/channels/mod.rs
+++ b/rings-core/src/channels/mod.rs
@@ -5,8 +5,7 @@ mod default;
 #[cfg(feature = "wasm")]
 mod wasm;
 
-#[cfg(feature = "wasm")]
-pub use wasm::CbChannel as Channel;
-
 #[cfg(not(feature = "wasm"))]
 pub use default::AcChannel as Channel;
+#[cfg(feature = "wasm")]
+pub use wasm::CbChannel as Channel;

--- a/rings-core/src/channels/wasm.rs
+++ b/rings-core/src/channels/wasm.rs
@@ -1,10 +1,13 @@
-use crate::err::{Error, Result};
-use crate::types::channel::Channel;
+use std::sync::Arc;
+
 /// ref: https://github.com/Ciantic/rust-shared-wasm-experiments/blob/master/src/lib.rs
 use async_trait::async_trait;
 use futures::channel::mpsc;
 use futures::lock::Mutex;
-use std::sync::Arc;
+
+use crate::err::Error;
+use crate::err::Result;
+use crate::types::channel::Channel;
 
 type Sender<T> = Arc<Mutex<mpsc::Sender<T>>>;
 type Receiver<T> = Arc<Mutex<mpsc::Receiver<T>>>;

--- a/rings-core/src/dht/chord.rs
+++ b/rings-core/src/dht/chord.rs
@@ -1,15 +1,20 @@
 #![warn(missing_docs)]
-use super::did::BiasId;
-use super::successor::Successor;
-use super::types::{Chord, ChordStablize, ChordStorage};
-use super::vnode::VirtualNode;
-use crate::dht::Did;
-use crate::err::{Error, Result};
-use crate::storage::MemStorage;
+use std::sync::Arc;
+
 use num_bigint::BigUint;
 use serde::Deserialize;
 use serde::Serialize;
-use std::sync::Arc;
+
+use super::did::BiasId;
+use super::successor::Successor;
+use super::types::Chord;
+use super::types::ChordStablize;
+use super::types::ChordStorage;
+use super::vnode::VirtualNode;
+use crate::dht::Did;
+use crate::err::Error;
+use crate::err::Result;
+use crate::storage::MemStorage;
 
 /// Remote actions
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -416,9 +421,10 @@ impl ChordStorage<PeerRingAction> for PeerRing {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
     use crate::ecc::SecretKey;
-    use std::str::FromStr;
 
     #[test]
     fn test_chord_finger() {

--- a/rings-core/src/dht/did.rs
+++ b/rings-core/src/dht/did.rs
@@ -1,14 +1,18 @@
-/// Did is a finate Ring R(P) where P = 2^160
-use crate::err::{Error, Result};
+use std::cmp::Eq;
+use std::cmp::PartialEq;
+use std::ops::Add;
+use std::ops::Deref;
+use std::ops::Neg;
+use std::ops::Sub;
+use std::str::FromStr;
+
 use num_bigint::BigUint;
 use serde::Deserialize;
 use serde::Serialize;
-use std::cmp::{Eq, PartialEq};
-use std::ops::Deref;
-use std::ops::Neg;
-use std::ops::{Add, Sub};
-use std::str::FromStr;
 use web3::types::H160;
+
+use crate::err::Error;
+use crate::err::Result;
 
 #[derive(Copy, Clone, Eq, Ord, PartialEq, PartialOrd, Debug, Serialize, Deserialize, Hash)]
 pub struct Did(H160);
@@ -163,8 +167,9 @@ impl Sub for Did {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::str::FromStr;
+
+    use super::*;
 
     #[test]
     fn test_did() {

--- a/rings-core/src/dht/mod.rs
+++ b/rings-core/src/dht/mod.rs
@@ -7,11 +7,16 @@ pub use did::Did;
 mod chord;
 mod successor;
 mod types;
-pub use {chord::PeerRing, chord::PeerRingAction, chord::RemoteAction as PeerRingRemoteAction};
-pub use {types::Chord, types::ChordStablize, types::ChordStorage};
+pub use chord::PeerRing;
+pub use chord::PeerRingAction;
+pub use chord::RemoteAction as PeerRingRemoteAction;
+pub use types::Chord;
+pub use types::ChordStablize;
+pub use types::ChordStorage;
 
 mod stabilization;
-pub use stabilization::{Stabilization, TStabilize};
+pub use stabilization::Stabilization;
+pub use stabilization::TStabilize;
 /// Implement SubRing with VNode
 pub mod subring;
 /// VNode is a special node that only has virtual address

--- a/rings-core/src/dht/stabilization.rs
+++ b/rings-core/src/dht/stabilization.rs
@@ -1,10 +1,18 @@
-use crate::dht::{ChordStablize, PeerRing, PeerRingAction, PeerRingRemoteAction};
-use crate::err::Result;
-use crate::message::{FindSuccessorSend, Message, NotifyPredecessorSend, PayloadSender};
-use crate::swarm::Swarm;
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use futures::lock::Mutex;
-use std::sync::Arc;
+
+use crate::dht::ChordStablize;
+use crate::dht::PeerRing;
+use crate::dht::PeerRingAction;
+use crate::dht::PeerRingRemoteAction;
+use crate::err::Result;
+use crate::message::FindSuccessorSend;
+use crate::message::Message;
+use crate::message::NotifyPredecessorSend;
+use crate::message::PayloadSender;
+use crate::swarm::Swarm;
 
 #[derive(Clone)]
 pub struct Stabilization {
@@ -88,12 +96,17 @@ impl Stabilization {
 
 #[cfg(not(feature = "wasm"))]
 mod stabilizer {
-    use super::{Stabilization, TStabilize};
-    use async_trait::async_trait;
-    use futures::{future::FutureExt, pin_mut, select};
-    use futures_timer::Delay;
     use std::sync::Arc;
     use std::time::Duration;
+
+    use async_trait::async_trait;
+    use futures::future::FutureExt;
+    use futures::pin_mut;
+    use futures::select;
+    use futures_timer::Delay;
+
+    use super::Stabilization;
+    use super::TStabilize;
 
     #[async_trait]
     impl TStabilize for Stabilization {
@@ -118,11 +131,14 @@ mod stabilizer {
 
 #[cfg(feature = "wasm")]
 mod stabilizer {
-    use super::{Stabilization, TStabilize};
-    use crate::poll;
-    use async_trait::async_trait;
     use std::sync::Arc;
+
+    use async_trait::async_trait;
     use wasm_bindgen_futures::spawn_local;
+
+    use super::Stabilization;
+    use super::TStabilize;
+    use crate::poll;
 
     #[async_trait(?Send)]
     impl TStabilize for Stabilization {

--- a/rings-core/src/dht/subring.rs
+++ b/rings-core/src/dht/subring.rs
@@ -1,11 +1,13 @@
 #![warn(missing_docs)]
+use std::str::FromStr;
+
 use super::chord::PeerRing;
 use super::vnode::VNodeType;
 use super::vnode::VirtualNode;
 use crate::dht::Did;
 use crate::ecc::HashStr;
-use crate::err::{Error, Result};
-use std::str::FromStr;
+use crate::err::Error;
+use crate::err::Result;
 
 /// A SubRing is a full functional Ring, but with a name and it's finger table can be
 /// stored on Main Rings DHT, For a SubRing, it's virtual address is `sha1(name)`

--- a/rings-core/src/dht/vnode.rs
+++ b/rings-core/src/dht/vnode.rs
@@ -1,15 +1,18 @@
 #![warn(missing_docs)]
-use crate::dht::Did;
-use crate::ecc::HashStr;
-use crate::err::{Error, Result};
-use crate::message::Encoded;
-use crate::message::Encoder;
-use crate::message::MessagePayload;
+use std::str::FromStr;
+
 use num_bigint::BigUint;
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde::Serialize;
-use std::str::FromStr;
+
+use crate::dht::Did;
+use crate::ecc::HashStr;
+use crate::err::Error;
+use crate::err::Result;
+use crate::message::Encoded;
+use crate::message::Encoder;
+use crate::message::MessagePayload;
 
 /// VNode Types
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -45,8 +48,7 @@ impl VirtualNode {
 }
 
 impl<T> TryFrom<MessagePayload<T>> for VirtualNode
-where
-    T: Serialize + DeserializeOwned,
+where T: Serialize + DeserializeOwned
 {
     type Error = Error;
     fn try_from(msg: MessagePayload<T>) -> Result<Self> {

--- a/rings-core/src/ecc/elgamal.rs
+++ b/rings-core/src/ecc/elgamal.rs
@@ -23,15 +23,18 @@
 //!    T. ElGamal. A Public Key Cryptosystem and a Signature Scheme Based on Discrete Logarithms. IEEE Trans. Info. Theory, IT 31:469–472, 1985.
 //!    ElGamal encryption <https://en.wikipedia.org/wiki/ElGamal_encryption>
 //!    <http://www.docsdrive.com/pdfs/ansinet/itj/2005/299-306.pdf>
-use crate::ecc::{CurveEle, PublicKey, SecretKey};
-use crate::err::Error;
-use crate::err::Result;
 use libsecp256k1::curve::Affine;
 use libsecp256k1::curve::ECMultContext;
 use libsecp256k1::curve::ECMultGenContext;
 use libsecp256k1::curve::Field;
 use libsecp256k1::curve::Jacobian;
 use libsecp256k1::curve::Scalar;
+
+use crate::ecc::CurveEle;
+use crate::ecc::PublicKey;
+use crate::ecc::SecretKey;
+use crate::err::Error;
+use crate::err::Result;
 
 pub fn str_to_field(s: &str) -> Vec<Field> {
     s.as_bytes()
@@ -172,8 +175,10 @@ pub fn decrypt(m: &[(CurveEle, CurveEle)], k: &SecretKey) -> Result<String> {
 
 #[cfg(test)]
 mod test {
+    use rand::distributions::Alphanumeric;
+    use rand::Rng;
+
     use super::*;
-    use rand::{distributions::Alphanumeric, Rng};
 
     fn random(len: usize) -> String {
         rand::thread_rng()

--- a/rings-core/src/ecc/mod.rs
+++ b/rings-core/src/ecc/mod.rs
@@ -1,18 +1,21 @@
 //! ECDSA and ElGamal
 
-use crate::err::{Error, Result};
-use hex;
+use std::convert::TryFrom;
+use std::fmt::Write;
+use std::ops::Deref;
 
+use hex;
 use rand::SeedableRng;
 use rand_hc::Hc128Rng;
 use serde::Deserialize;
 use serde::Serialize;
-use sha1::{Digest, Sha1};
-use std::convert::TryFrom;
-use std::fmt::Write;
-use std::ops::Deref;
+use sha1::Digest;
+use sha1::Sha1;
 use web3::signing::keccak256;
 use web3::types::Address;
+
+use crate::err::Error;
+use crate::err::Result;
 pub mod elgamal;
 pub mod signers;
 
@@ -104,8 +107,7 @@ impl From<SecretKey> for PublicKey {
 }
 
 impl<T> From<T> for HashStr
-where
-    T: Into<String>,
+where T: Into<String>
 {
     fn from(s: T) -> Self {
         let inputs = s.into();
@@ -199,9 +201,7 @@ impl PublicKey {
 }
 
 pub fn recover<S>(message: &str, signature: S) -> Result<PublicKey>
-where
-    S: AsRef<[u8]>,
-{
+where S: AsRef<[u8]> {
     let sig_bytes: SigBytes = signature.as_ref().try_into()?;
     let message_hash: [u8; 32] = keccak256(message.as_bytes());
     recover_hash(&message_hash, &sig_bytes)
@@ -223,8 +223,9 @@ pub fn recover_hash(message_hash: &[u8; 32], sig: &[u8; 65]) -> Result<PublicKey
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use hex::FromHex;
+
+    use super::*;
 
     #[test]
     fn test_parse_to_string_with_sha10x00() {

--- a/rings-core/src/ecc/signers.rs
+++ b/rings-core/src/ecc/signers.rs
@@ -1,9 +1,10 @@
 //! Signer for default ECDSA and EIP712
+use web3::signing::keccak256;
+
 use crate::ecc::Address;
 use crate::ecc::PublicKey;
 use crate::ecc::SecretKey;
 use crate::err::Result;
-use web3::signing::keccak256;
 
 pub mod default {
 
@@ -69,10 +70,11 @@ pub mod eip712 {
 
 #[cfg(test)]
 mod test {
+    use std::str::FromStr;
+
     use super::*;
     use crate::ecc::Address;
     use crate::ecc::SecretKey;
-    use std::str::FromStr;
 
     #[test]
     fn test_default_sign() {

--- a/rings-core/src/message/encoder.rs
+++ b/rings-core/src/message/encoder.rs
@@ -1,9 +1,11 @@
-use crate::err::Error;
-use crate::err::Result;
+use std::ops::Deref;
+
 use base58_monero as b58m;
 use serde::Deserialize;
 use serde::Serialize;
-use std::ops::Deref;
+
+use crate::err::Error;
+use crate::err::Result;
 
 pub trait Encoder {
     fn encode(&self) -> Result<Encoded>;
@@ -110,9 +112,7 @@ impl Encoded {
     }
 
     pub fn decode<T>(&self) -> Result<T>
-    where
-        T: Decoder,
-    {
+    where T: Decoder {
         T::from_encoded(self)
     }
 }

--- a/rings-core/src/message/handlers/connection.rs
+++ b/rings-core/src/message/handlers/connection.rs
@@ -1,19 +1,33 @@
+use std::str::FromStr;
+
+use async_trait::async_trait;
+
+use crate::dht::Chord;
+use crate::dht::ChordStablize;
 use crate::dht::ChordStorage;
-use crate::dht::{Chord, ChordStablize, PeerRingAction, PeerRingRemoteAction};
-use crate::err::{Error, Result};
-use crate::message::types::{
-    AlreadyConnected, ConnectNodeReport, ConnectNodeSend, FindSuccessorReport, FindSuccessorSend,
-    JoinDHT, Message, NotifyPredecessorReport, NotifyPredecessorSend, SyncVNodeWithSuccessor,
-};
+use crate::dht::PeerRingAction;
+use crate::dht::PeerRingRemoteAction;
+use crate::err::Error;
+use crate::err::Result;
+use crate::message::types::AlreadyConnected;
+use crate::message::types::ConnectNodeReport;
+use crate::message::types::ConnectNodeSend;
+use crate::message::types::FindSuccessorReport;
+use crate::message::types::FindSuccessorSend;
+use crate::message::types::JoinDHT;
+use crate::message::types::Message;
+use crate::message::types::NotifyPredecessorReport;
+use crate::message::types::NotifyPredecessorSend;
+use crate::message::types::SyncVNodeWithSuccessor;
 use crate::message::HandleMsg;
 use crate::message::LeaveDHT;
 use crate::message::MessageHandler;
-use crate::message::{MessagePayload, PayloadSender, RelayMethod};
+use crate::message::MessagePayload;
+use crate::message::PayloadSender;
+use crate::message::RelayMethod;
 use crate::prelude::RTCSdpType;
 use crate::swarm::TransportManager;
 use crate::types::ice_transport::IceTrickleScheme;
-use async_trait::async_trait;
-use std::str::FromStr;
 
 #[cfg_attr(feature = "wasm", async_trait(?Send))]
 #[cfg_attr(not(feature = "wasm"), async_trait)]
@@ -275,6 +289,10 @@ impl HandleMsg<NotifyPredecessorReport> for MessageHandler {
 #[cfg(not(feature = "wasm"))]
 #[cfg(test)]
 mod test {
+    use std::sync::Arc;
+
+    use futures::lock::Mutex;
+
     use super::*;
     use crate::dht::PeerRing;
     use crate::ecc::SecretKey;
@@ -284,8 +302,6 @@ mod test {
     use crate::swarm::Swarm;
     use crate::swarm::TransportManager;
     use crate::types::ice_transport::IceTrickleScheme;
-    use futures::lock::Mutex;
-    use std::sync::Arc;
 
     #[tokio::test]
     async fn test_triple_node() -> Result<()> {

--- a/rings-core/src/message/handlers/storage.rs
+++ b/rings-core/src/message/handlers/storage.rs
@@ -1,10 +1,21 @@
-use crate::dht::vnode::VirtualNode;
-use crate::dht::Did;
-use crate::dht::{ChordStorage, PeerRingAction, PeerRingRemoteAction};
-use crate::err::{Error, Result};
-use crate::message::types::{FoundVNode, Message, SearchVNode, StoreVNode, SyncVNodeWithSuccessor};
-use crate::message::{HandleMsg, MessageHandler, MessagePayload, PayloadSender};
 use async_trait::async_trait;
+
+use crate::dht::vnode::VirtualNode;
+use crate::dht::ChordStorage;
+use crate::dht::Did;
+use crate::dht::PeerRingAction;
+use crate::dht::PeerRingRemoteAction;
+use crate::err::Error;
+use crate::err::Result;
+use crate::message::types::FoundVNode;
+use crate::message::types::Message;
+use crate::message::types::SearchVNode;
+use crate::message::types::StoreVNode;
+use crate::message::types::SyncVNodeWithSuccessor;
+use crate::message::HandleMsg;
+use crate::message::MessageHandler;
+use crate::message::MessagePayload;
+use crate::message::PayloadSender;
 
 /// TChordStorage should imply necessary method for DHT storage
 #[cfg_attr(feature = "wasm", async_trait(?Send))]
@@ -178,6 +189,10 @@ impl HandleMsg<SyncVNodeWithSuccessor> for MessageHandler {
 #[cfg(not(feature = "wasm"))]
 #[cfg(test)]
 mod test {
+    use std::sync::Arc;
+
+    use futures::lock::Mutex;
+
     use super::*;
     use crate::dht::PeerRing;
     use crate::ecc::SecretKey;
@@ -187,8 +202,6 @@ mod test {
     use crate::swarm::Swarm;
     use crate::swarm::TransportManager;
     use crate::types::ice_transport::IceTrickleScheme;
-    use futures::lock::Mutex;
-    use std::sync::Arc;
 
     #[tokio::test]
     async fn test_store_vnode() -> Result<()> {

--- a/rings-core/src/message/payload.rs
+++ b/rings-core/src/message/payload.rs
@@ -1,18 +1,27 @@
-use super::encoder::{Decoder, Encoded, Encoder};
-use super::protocols::{MessageRelay, MessageVerification, RelayMethod};
-use crate::dht::Did;
-use crate::ecc::{HashStr, PublicKey};
-use crate::err::{Error, Result};
-use crate::session::SessionManager;
-use crate::utils;
+use std::io::Write;
+
 use async_trait::async_trait;
-use flate2::write::{GzDecoder, GzEncoder};
+use flate2::write::GzDecoder;
+use flate2::write::GzEncoder;
 use flate2::Compression;
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde::Serialize;
-use std::io::Write;
 use web3::types::Address;
+
+use super::encoder::Decoder;
+use super::encoder::Encoded;
+use super::encoder::Encoder;
+use super::protocols::MessageRelay;
+use super::protocols::MessageVerification;
+use super::protocols::RelayMethod;
+use crate::dht::Did;
+use crate::ecc::HashStr;
+use crate::ecc::PublicKey;
+use crate::err::Error;
+use crate::err::Result;
+use crate::session::SessionManager;
+use crate::utils;
 
 const DEFAULT_TTL_MS: usize = 60 * 1000;
 
@@ -32,8 +41,7 @@ pub struct MessagePayload<T> {
 }
 
 impl<T> MessagePayload<T>
-where
-    T: Serialize + DeserializeOwned,
+where T: Serialize + DeserializeOwned
 {
     pub fn new(
         data: T,
@@ -124,9 +132,7 @@ where
     }
 
     pub fn from_gzipped(data: &[u8]) -> Result<Self>
-    where
-        T: DeserializeOwned,
-    {
+    where T: DeserializeOwned {
         let mut writer = Vec::new();
         let mut decoder = GzDecoder::new(writer);
         decoder.write_all(data).map_err(|_| Error::GzipDecode)?;
@@ -153,8 +159,7 @@ where
 }
 
 impl<T> Encoder for MessagePayload<T>
-where
-    T: Serialize + DeserializeOwned,
+where T: Serialize + DeserializeOwned
 {
     fn encode(&self) -> Result<Encoded> {
         self.gzip(9)?.encode()
@@ -162,8 +167,7 @@ where
 }
 
 impl<T> Decoder for MessagePayload<T>
-where
-    T: Serialize + DeserializeOwned,
+where T: Serialize + DeserializeOwned
 {
     fn from_encoded(encoded: &Encoded) -> Result<Self> {
         let v: Vec<u8> = encoded.decode()?;
@@ -174,8 +178,7 @@ where
 #[cfg_attr(feature = "wasm", async_trait(?Send))]
 #[cfg_attr(not(feature = "wasm"), async_trait)]
 pub trait PayloadSender<T>
-where
-    T: Clone + Serialize + DeserializeOwned + Send + Sync + 'static,
+where T: Clone + Serialize + DeserializeOwned + Send + Sync + 'static
 {
     fn session_manager(&self) -> &SessionManager;
     async fn do_send_payload(&self, address: &Address, payload: MessagePayload<T>) -> Result<()>;

--- a/rings-core/src/message/protocols/mod.rs
+++ b/rings-core/src/message/protocols/mod.rs
@@ -1,5 +1,6 @@
 mod relay;
 mod verify;
 
-pub use self::relay::{MessageRelay, RelayMethod};
+pub use self::relay::MessageRelay;
+pub use self::relay::RelayMethod;
 pub use self::verify::MessageVerification;

--- a/rings-core/src/message/protocols/relay.rs
+++ b/rings-core/src/message/protocols/relay.rs
@@ -6,10 +6,12 @@
 //! - Get the sender and origin sender of a message.
 //! - Record the whole transport path for inspection.
 
-use crate::dht::Did;
-use crate::err::{Error, Result};
 use serde::Deserialize;
 use serde::Serialize;
+
+use crate::dht::Did;
+use crate::err::Error;
+use crate::err::Result;
 
 /// `MessageRelay` divides messages into two types by method: SEND and REPORT.
 /// And will enable different behaviors when handling SEND and REPORT messages.

--- a/rings-core/src/message/protocols/verify.rs
+++ b/rings-core/src/message/protocols/verify.rs
@@ -1,8 +1,12 @@
-use crate::ecc::{signers, PublicKey};
-use crate::err::{Error, Result};
-use crate::session::{Session, Signer};
 use serde::Deserialize;
 use serde::Serialize;
+
+use crate::ecc::signers;
+use crate::ecc::PublicKey;
+use crate::err::Error;
+use crate::err::Result;
+use crate::session::Session;
+use crate::session::Signer;
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 pub struct MessageVerification {
@@ -14,9 +18,7 @@ pub struct MessageVerification {
 
 impl MessageVerification {
     pub fn verify<T>(&self, data: &T) -> bool
-    where
-        T: Serialize,
-    {
+    where T: Serialize {
         if !self.session.verify() {
             return false;
         }
@@ -32,9 +34,7 @@ impl MessageVerification {
     }
 
     pub fn session_pubkey<T>(&self, data: &T) -> Result<PublicKey>
-    where
-        T: Serialize,
-    {
+    where T: Serialize {
         let msg = self.msg(data)?;
         match self.session.auth.signer {
             Signer::DEFAULT => signers::default::recover(&msg, &self.sig),
@@ -43,18 +43,14 @@ impl MessageVerification {
     }
 
     pub fn pack_msg<T>(data: &T, ts_ms: u128, ttl_ms: usize) -> Result<String>
-    where
-        T: Serialize,
-    {
+    where T: Serialize {
         let mut msg = serde_json::to_string(data).map_err(|_| Error::SerializeToString)?;
         msg.push_str(&format!("\n{}\n{}", ts_ms, ttl_ms));
         Ok(msg)
     }
 
     fn msg<T>(&self, data: &T) -> Result<String>
-    where
-        T: Serialize,
-    {
+    where T: Serialize {
         Self::pack_msg(data, self.ts_ms, self.ttl_ms)
     }
 }

--- a/rings-core/src/message/types.rs
+++ b/rings-core/src/message/types.rs
@@ -1,10 +1,14 @@
-use crate::dht::{vnode::VirtualNode, Did};
-use crate::ecc::elgamal;
-use crate::ecc::{PublicKey, SecretKey};
-use crate::err::{Error, Result};
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde::Serialize;
+
+use crate::dht::vnode::VirtualNode;
+use crate::dht::Did;
+use crate::ecc::elgamal;
+use crate::ecc::PublicKey;
+use crate::ecc::SecretKey;
+use crate::err::Error;
+use crate::err::Result;
 
 #[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
 pub struct ConnectNodeSend {
@@ -126,8 +130,7 @@ impl Message {
 }
 
 impl<T> MaybeEncrypted<T>
-where
-    T: Serialize + DeserializeOwned,
+where T: Serialize + DeserializeOwned
 {
     pub fn new(data: T, pubkey: &Option<PublicKey>) -> Result<Self> {
         if let Some(pubkey) = pubkey {

--- a/rings-core/src/prelude.rs
+++ b/rings-core/src/prelude.rs
@@ -1,24 +1,21 @@
 //! prelude
 
-#[cfg(feature = "wasm")]
-pub use web_sys::RtcSdpType as RTCSdpType;
-#[cfg(not(feature = "wasm"))]
-pub use webrtc::peer_connection::sdp::sdp_type::RTCSdpType;
-
 pub use async_trait;
 pub use dashmap;
 pub use futures;
-pub use uuid;
-pub use web3;
-
-pub use url;
-#[cfg(feature = "wasm")]
-pub use web_sys;
-#[cfg(feature = "default")]
-pub use webrtc;
-
 #[cfg(feature = "wasm")]
 pub use js_sys;
+pub use url;
+pub use uuid;
 #[cfg(feature = "wasm")]
 pub use wasm_bindgen;
+pub use web3;
 pub use web3::types::Address;
+#[cfg(feature = "wasm")]
+pub use web_sys;
+#[cfg(feature = "wasm")]
+pub use web_sys::RtcSdpType as RTCSdpType;
+#[cfg(feature = "default")]
+pub use webrtc;
+#[cfg(not(feature = "wasm"))]
+pub use webrtc::peer_connection::sdp::sdp_type::RTCSdpType;

--- a/rings-core/src/session.rs
+++ b/rings-core/src/session.rs
@@ -5,16 +5,19 @@
 //! - Then we can sign the auth message via some web3 provider like metamask or just with raw private key, and create the SessionManger with
 //! - SessionManager::new(sig, auth_info, temp_key)
 
+use std::sync::Arc;
+use std::sync::RwLock;
+
+use serde::Deserialize;
+use serde::Serialize;
+use web3::types::Address;
+
 use crate::ecc::signers;
 use crate::ecc::PublicKey;
 use crate::ecc::SecretKey;
-use crate::err::{Error, Result};
+use crate::err::Error;
+use crate::err::Result;
 use crate::utils;
-use serde::Deserialize;
-use serde::Serialize;
-use std::sync::Arc;
-use std::sync::RwLock;
-use web3::types::Address;
 
 const DEFAULT_TTL_MS: usize = 24 * 3600 * 1000;
 

--- a/rings-core/src/storage/memory.rs
+++ b/rings-core/src/storage/memory.rs
@@ -1,5 +1,6 @@
-use dashmap::DashMap;
 use std::hash::Hash;
+
+use dashmap::DashMap;
 
 #[derive(Clone, Debug, Default)]
 pub struct MemStorage<K, V>
@@ -67,9 +68,10 @@ where
 
 #[cfg(test)]
 mod tests {
+    use web3::types::Address;
+
     use super::*;
     use crate::ecc::SecretKey;
-    use web3::types::Address;
 
     #[test]
     fn memstorage_basic_interface_should_work() {

--- a/rings-core/src/storage/mod.rs
+++ b/rings-core/src/storage/mod.rs
@@ -1,13 +1,12 @@
 mod memory;
 pub mod persistence;
 
-pub use self::persistence::{
-    PersistenceStorageOperation, PersistenceStorageReadAndWrite, PersistenceStorageRemove,
-};
 pub use memory::MemStorage;
 
 #[cfg(feature = "wasm")]
 pub use self::persistence::idb::IDBStorage as Storage;
-
 #[cfg(feature = "default")]
 pub use self::persistence::kv::KvStorage as Storage;
+pub use self::persistence::PersistenceStorageOperation;
+pub use self::persistence::PersistenceStorageReadAndWrite;
+pub use self::persistence::PersistenceStorageRemove;

--- a/rings-core/src/storage/persistence/idb.rs
+++ b/rings-core/src/storage/persistence/idb.rs
@@ -1,19 +1,27 @@
 #![warn(missing_docs)]
 
 //! Storage for wasm
-use super::{
-    PersistenceStorageOperation, PersistenceStorageReadAndWrite, PersistenceStorageRemove,
-};
-use crate::err::{Error, Result};
+use std::mem::size_of_val;
+use std::ops::Add;
+use std::ops::Sub;
+
 use async_trait::async_trait;
 use chrono;
-use rexie::{self, Index, ObjectStore, Rexie, TransactionMode};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use std::{
-    mem::size_of_val,
-    ops::{Add, Sub},
-};
+use rexie::Index;
+use rexie::ObjectStore;
+use rexie::Rexie;
+use rexie::TransactionMode;
+use rexie::{self};
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
+use serde::Serialize;
 use wasm_bindgen::JsValue;
+
+use super::PersistenceStorageOperation;
+use super::PersistenceStorageReadAndWrite;
+use super::PersistenceStorageRemove;
+use crate::err::Error;
+use crate::err::Result;
 
 const REXIE_STORE_NAME: &str = "rings-storage";
 

--- a/rings-core/src/storage/persistence/mod.rs
+++ b/rings-core/src/storage/persistence/mod.rs
@@ -2,11 +2,11 @@
 pub mod idb;
 #[cfg(feature = "default")]
 pub mod kv;
-use crate::err::Result;
 use async_trait::async_trait;
 
 #[cfg(feature = "wasm")]
 pub use self::idb::IDBStorage;
+use crate::err::Result;
 
 /// Persistence Storage read and write functions
 #[cfg_attr(feature = "wasm", async_trait(?Send))]

--- a/rings-core/src/transports/default/mod.rs
+++ b/rings-core/src/transports/default/mod.rs
@@ -1,8 +1,9 @@
 pub mod transport;
 
-use crate::types::ice_transport::IceCandidate;
 pub use transport::DefaultTransport;
 use webrtc::ice_transport::ice_candidate::RTCIceCandidateInit;
+
+use crate::types::ice_transport::IceCandidate;
 
 impl From<RTCIceCandidateInit> for IceCandidate {
     fn from(cand: RTCIceCandidateInit) -> Self {

--- a/rings-core/src/transports/helper.rs
+++ b/rings-core/src/transports/helper.rs
@@ -1,13 +1,16 @@
-use crate::err::{Error, Result};
-use crate::types::ice_transport::IceCandidate;
-use serde::Deserialize;
-use serde::Serialize;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::task::Context;
 use std::task::Poll;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::err::Error;
+use crate::err::Result;
+use crate::types::ice_transport::IceCandidate;
 
 #[derive(Default)]
 pub struct State {

--- a/rings-core/src/transports/wasm/helper.rs
+++ b/rings-core/src/transports/wasm/helper.rs
@@ -1,10 +1,12 @@
-use crate::err::{Error, Result};
 use serde::Deserialize;
 use serde::Serialize;
 use serde_json;
 use wasm_bindgen::JsValue;
 use web_sys::RtcSdpType;
 use web_sys::RtcSessionDescription;
+
+use crate::err::Error;
+use crate::err::Result;
 
 #[derive(Clone, Deserialize, Serialize, Debug)]
 #[serde(rename_all = "lowercase")]

--- a/rings-core/src/transports/wasm/mod.rs
+++ b/rings-core/src/transports/wasm/mod.rs
@@ -1,9 +1,10 @@
 mod helper;
 mod transport;
-use crate::types::ice_transport::IceCandidate;
 pub use transport::WasmTransport;
 use wasm_bindgen::JsValue;
 use web_sys::RtcIceCandidateInit;
+
+use crate::types::ice_transport::IceCandidate;
 
 impl From<IceCandidate> for RtcIceCandidateInit {
     fn from(cand: IceCandidate) -> Self {

--- a/rings-core/src/transports/wasm/transport.rs
+++ b/rings-core/src/transports/wasm/transport.rs
@@ -1,25 +1,11 @@
-use super::helper::RtcSessionDescriptionWrapper;
-use crate::channels::Channel as CbChannel;
-use crate::ecc::PublicKey;
-use crate::err::{Error, Result};
-use crate::message::{Encoded, Encoder, MessagePayload};
-use crate::session::SessionManager;
-use crate::transports::helper::Promise;
-use crate::transports::helper::TricklePayload;
-use crate::types::channel::Channel;
-use crate::types::channel::Event;
-use crate::types::ice_transport::IceCandidate;
-use crate::types::ice_transport::IceServer;
-use crate::types::ice_transport::IceTransport;
-use crate::types::ice_transport::IceTransportCallback;
-use crate::types::ice_transport::IceTrickleScheme;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::RwLock;
+
 use async_trait::async_trait;
 use futures::channel::mpsc;
 use futures::lock::Mutex as FuturesMutex;
 use js_sys::Uint8Array;
-use std::sync::Arc;
-use std::sync::Mutex;
-use std::sync::RwLock;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::JsValue;
@@ -40,6 +26,25 @@ use web_sys::RtcPeerConnectionIceEvent;
 use web_sys::RtcSdpType;
 use web_sys::RtcSessionDescription;
 use web_sys::RtcSessionDescriptionInit;
+
+use super::helper::RtcSessionDescriptionWrapper;
+use crate::channels::Channel as CbChannel;
+use crate::ecc::PublicKey;
+use crate::err::Error;
+use crate::err::Result;
+use crate::message::Encoded;
+use crate::message::Encoder;
+use crate::message::MessagePayload;
+use crate::session::SessionManager;
+use crate::transports::helper::Promise;
+use crate::transports::helper::TricklePayload;
+use crate::types::channel::Channel;
+use crate::types::channel::Event;
+use crate::types::ice_transport::IceCandidate;
+use crate::types::ice_transport::IceServer;
+use crate::types::ice_transport::IceTransport;
+use crate::types::ice_transport::IceTransportCallback;
+use crate::types::ice_transport::IceTrickleScheme;
 
 type EventSender = Arc<FuturesMutex<mpsc::Sender<Event>>>;
 
@@ -204,9 +209,7 @@ impl IceTransport<Event, CbChannel<Event>> for WasmTransport {
     }
 
     async fn set_local_description<T>(&self, desc: T) -> Result<()>
-    where
-        T: Into<Self::Sdp>,
-    {
+    where T: Into<Self::Sdp> {
         match &self.get_peer_connection().await {
             Some(c) => {
                 let sdp: Self::Sdp = desc.into();
@@ -226,9 +229,7 @@ impl IceTransport<Event, CbChannel<Event>> for WasmTransport {
     }
 
     async fn set_remote_description<T>(&self, desc: T) -> Result<()>
-    where
-        T: Into<Self::Sdp>,
-    {
+    where T: Into<Self::Sdp> {
         match &self.get_peer_connection().await {
             Some(c) => {
                 let sdp: Self::Sdp = desc.into();

--- a/rings-core/src/types/channel.rs
+++ b/rings-core/src/types/channel.rs
@@ -1,7 +1,8 @@
-use crate::err::Result;
 use async_trait::async_trait;
 use serde::Serialize;
 use web3::types::Address;
+
+use crate::err::Result;
 
 #[derive(Debug, PartialEq, Serialize, Clone)]
 pub enum Event {

--- a/rings-core/src/types/ice_transport/ice_server.rs
+++ b/rings-core/src/types/ice_transport/ice_server.rs
@@ -1,8 +1,11 @@
-use crate::err::{Error, Result};
+use std::str::FromStr;
+
 use serde::Deserialize;
 use serde::Serialize;
-use std::str::FromStr;
 use url::Url;
+
+use crate::err::Error;
+use crate::err::Result;
 
 #[derive(Deserialize, Serialize, Debug, Clone, Default, PartialEq)]
 pub enum IceCredentialType {
@@ -69,12 +72,13 @@ impl FromStr for IceServer {
 
 #[cfg(feature = "wasm")]
 mod wasm {
-    use super::IceCredentialType;
-    use super::IceServer;
     use js_sys::Array;
     use wasm_bindgen::JsValue;
     use web_sys::RtcIceCredentialType;
     use web_sys::RtcIceServer;
+
+    use super::IceCredentialType;
+    use super::IceServer;
 
     // set default to password
     impl From<IceCredentialType> for RtcIceCredentialType {
@@ -117,10 +121,11 @@ mod wasm {
 
 #[cfg(not(feature = "wasm"))]
 mod default {
-    use super::IceCredentialType;
-    use super::IceServer;
     use webrtc::ice_transport::ice_credential_type::RTCIceCredentialType;
     use webrtc::ice_transport::ice_server::RTCIceServer;
+
+    use super::IceCredentialType;
+    use super::IceServer;
 
     impl From<IceCredentialType> for RTCIceCredentialType {
         fn from(s: IceCredentialType) -> Self {
@@ -146,8 +151,9 @@ mod default {
 
 #[cfg(test)]
 mod test {
-    use super::IceServer;
     use std::str::FromStr;
+
+    use super::IceServer;
 
     #[test]
     fn test_parsing() {

--- a/rings-core/src/types/ice_transport/mod.rs
+++ b/rings-core/src/types/ice_transport/mod.rs
@@ -1,15 +1,17 @@
 pub mod ice_server;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde::Deserialize;
+use serde::Serialize;
+use web3::types::Address;
+
 pub use self::ice_server::IceServer;
 use crate::ecc::PublicKey;
 use crate::err::Result;
 use crate::message::Encoded;
 use crate::session::SessionManager;
 use crate::types::channel::Channel;
-use async_trait::async_trait;
-use serde::Deserialize;
-use serde::Serialize;
-use std::sync::Arc;
-use web3::types::Address;
 
 /// Struct From [webrtc-rs](https://docs.rs/webrtc/latest/webrtc/ice_transport/ice_candidate/struct.RTCIceCandidateInit.html)
 /// For [RFC Std](https://w3c.github.io/webrtc-pc/#dom-rtcicecandidate-tojson), ICE Candidate should be camelCase
@@ -53,12 +55,10 @@ pub trait IceTransport<E: Send, Ch: Channel<E>> {
     async fn get_data_channel(&self) -> Option<Arc<Self::DataChannel>>;
     async fn send_message(&self, msg: &[u8]) -> Result<()>;
     async fn set_local_description<T>(&self, desc: T) -> Result<()>
-    where
-        T: Into<Self::Sdp> + Send;
+    where T: Into<Self::Sdp> + Send;
     async fn add_ice_candidate(&self, candidate: IceCandidate) -> Result<()>;
     async fn set_remote_description<T>(&self, desc: T) -> Result<()>
-    where
-        T: Into<Self::Sdp> + Send;
+    where T: Into<Self::Sdp> + Send;
 }
 
 #[cfg_attr(feature = "wasm", async_trait(?Send))]

--- a/rings-core/src/types/message.rs
+++ b/rings-core/src/types/message.rs
@@ -1,5 +1,6 @@
-use async_trait::async_trait;
 use std::sync::Arc;
+
+use async_trait::async_trait;
 
 #[cfg_attr(feature = "wasm", async_trait(?Send))]
 #[cfg_attr(not(feature = "wasm"), async_trait)]

--- a/rings-core/tests/default/test_message_handler.rs
+++ b/rings-core/tests/default/test_message_handler.rs
@@ -1,8 +1,12 @@
 #[cfg(test)]
 pub mod test {
+    use std::str::FromStr;
+    use std::sync::Arc;
+
     use futures::lock::Mutex;
     use rings_core::dht::vnode::VirtualNode;
-    use rings_core::dht::{Did, PeerRing};
+    use rings_core::dht::Did;
+    use rings_core::dht::PeerRing;
     use rings_core::ecc::SecretKey;
     use rings_core::err::Result;
     use rings_core::message;
@@ -17,9 +21,8 @@ pub mod test {
     use rings_core::types::ice_transport::IceTransport;
     use rings_core::types::ice_transport::IceTrickleScheme;
     use rings_core::types::message::MessageListener;
-    use std::str::FromStr;
-    use std::sync::Arc;
-    use tokio::time::{sleep, Duration};
+    use tokio::time::sleep;
+    use tokio::time::Duration;
     use webrtc::ice_transport::ice_connection_state::RTCIceConnectionState;
     use webrtc::peer_connection::sdp::sdp_type::RTCSdpType;
 

--- a/rings-core/tests/default/test_stabilize.rs
+++ b/rings-core/tests/default/test_stabilize.rs
@@ -1,8 +1,11 @@
 #[cfg(test)]
 pub mod test {
+    use std::sync::Arc;
+
     use futures::lock::Mutex;
+    use rings_core::dht::Did;
+    use rings_core::dht::PeerRing;
     use rings_core::dht::Stabilization;
-    use rings_core::dht::{Did, PeerRing};
     use rings_core::ecc::SecretKey;
     use rings_core::err::Result;
     use rings_core::message::MessageHandler;
@@ -13,8 +16,8 @@ pub mod test {
     use rings_core::types::ice_transport::IceTransport;
     use rings_core::types::ice_transport::IceTrickleScheme;
     use rings_core::types::message::MessageListener;
-    use std::sync::Arc;
-    use tokio::time::{sleep, Duration};
+    use tokio::time::sleep;
+    use tokio::time::Duration;
     use webrtc::ice_transport::ice_connection_state::RTCIceConnectionState;
     use webrtc::peer_connection::sdp::sdp_type::RTCSdpType;
 

--- a/rings-core/tests/wasm/test_ice_servers.rs
+++ b/rings-core/tests/wasm/test_ice_servers.rs
@@ -1,9 +1,10 @@
 #[cfg(test)]
 pub mod test {
+    use std::str::FromStr;
+
     use js_sys::Array;
     use js_sys::Reflect;
     use rings_core::types::ice_transport::ice_server::IceServer;
-    use std::str::FromStr;
     use wasm_bindgen::JsCast;
     use wasm_bindgen::JsValue;
     use wasm_bindgen_test::wasm_bindgen_test;

--- a/rings-core/tests/wasm/test_idb_storage.rs
+++ b/rings-core/tests/wasm/test_idb_storage.rs
@@ -1,11 +1,13 @@
 use std::mem::size_of_val;
 
 use rexie::TransactionMode;
-use rings_core::storage::persistence::{
-    idb::IDBStorageBasic, IDBStorage, PersistenceStorageOperation, PersistenceStorageReadAndWrite,
-    PersistenceStorageRemove,
-};
-use serde::{Deserialize, Serialize};
+use rings_core::storage::persistence::idb::IDBStorageBasic;
+use rings_core::storage::persistence::IDBStorage;
+use rings_core::storage::persistence::PersistenceStorageOperation;
+use rings_core::storage::persistence::PersistenceStorageReadAndWrite;
+use rings_core::storage::persistence::PersistenceStorageRemove;
+use serde::Deserialize;
+use serde::Serialize;
 use serde_json::Value as JsonValue;
 use wasm_bindgen::JsValue;
 use wasm_bindgen_test::wasm_bindgen_test;
@@ -175,39 +177,27 @@ async fn test_idb_prune() {
     let key4 = "4".to_string();
     let key5 = "5".to_string();
     instance
-        .put(
-            &key1,
-            &TestDataStruct {
-                content: "test1".to_owned(),
-            },
-        )
+        .put(&key1, &TestDataStruct {
+            content: "test1".to_owned(),
+        })
         .await
         .unwrap();
     instance
-        .put(
-            &key2,
-            &TestDataStruct {
-                content: "test2".to_owned(),
-            },
-        )
+        .put(&key2, &TestDataStruct {
+            content: "test2".to_owned(),
+        })
         .await
         .unwrap();
     instance
-        .put(
-            &key3,
-            &TestDataStruct {
-                content: "test3".to_owned(),
-            },
-        )
+        .put(&key3, &TestDataStruct {
+            content: "test3".to_owned(),
+        })
         .await
         .unwrap();
     instance
-        .put(
-            &key4,
-            &TestDataStruct {
-                content: "test4".to_owned(),
-            },
-        )
+        .put(&key4, &TestDataStruct {
+            content: "test4".to_owned(),
+        })
         .await
         .unwrap();
 
@@ -221,12 +211,9 @@ async fn test_idb_prune() {
     log::debug!("d2, {:?}", d2);
 
     instance
-        .put(
-            &key5,
-            &TestDataStruct {
-                content: "test5".to_owned(),
-            },
-        )
+        .put(&key5, &TestDataStruct {
+            content: "test5".to_owned(),
+        })
         .await
         .unwrap();
 

--- a/rings-core/tests/wasm/test_wasm_transport.rs
+++ b/rings-core/tests/wasm/test_wasm_transport.rs
@@ -1,5 +1,8 @@
 #[cfg(test)]
 pub mod test {
+    use std::str::FromStr;
+    use std::sync::Arc;
+
     use futures::lock::Mutex;
     use rings_core::channels::Channel as CbChannel;
     use rings_core::dht::PeerRing;
@@ -17,8 +20,6 @@ pub mod test {
     use rings_core::types::ice_transport::IceTransport;
     use rings_core::types::ice_transport::IceTransportCallback;
     use rings_core::types::ice_transport::IceTrickleScheme;
-    use std::str::FromStr;
-    use std::sync::Arc;
     use wasm_bindgen::JsValue;
     use wasm_bindgen_futures::JsFuture;
     use wasm_bindgen_test::*;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,13 @@
+edition = "2021"
 tab_spaces = 4
 format_code_in_doc_comments = true
 wrap_comments = false
 format_strings = false
 hard_tabs = false
+reorder_imports = true
+imports_granularity = "Item"
+group_imports = "StdExternalCrate"
+where_single_line = true
+trailing_comma = "Vertical"
+report_fixme = "Unnumbered"
+overflow_delimited_expr = true

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -2,30 +2,38 @@
 #![allow(clippy::unused_unit)]
 pub mod utils;
 
-use crate::{
-    prelude::rings_core::{
-        async_trait,
-        dht::PeerRing,
-        ecc::SecretKey,
-        message::{
-            CustomMessage, Encoded, MaybeEncrypted, Message, MessageCallback, MessageHandler,
-            MessagePayload,
-        },
-        prelude::web3::types::Address,
-        session::SessionManager,
-        session::{AuthorizedInfo, Signer},
-        swarm::{Swarm, TransportManager},
-        transports::Transport,
-        types::{ice_transport::IceTransport, message::MessageListener},
-    },
-    processor::{self, Processor},
-};
+use std::str::FromStr;
+use std::sync::Arc;
+
 use futures::lock::Mutex;
 use js_sys::Promise;
-use serde::{Deserialize, Serialize};
-use std::{str::FromStr, sync::Arc};
+use serde::Deserialize;
+use serde::Serialize;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen_futures::{future_to_promise, spawn_local};
+use wasm_bindgen_futures::future_to_promise;
+use wasm_bindgen_futures::spawn_local;
+
+use crate::prelude::rings_core::async_trait;
+use crate::prelude::rings_core::dht::PeerRing;
+use crate::prelude::rings_core::ecc::SecretKey;
+use crate::prelude::rings_core::message::CustomMessage;
+use crate::prelude::rings_core::message::Encoded;
+use crate::prelude::rings_core::message::MaybeEncrypted;
+use crate::prelude::rings_core::message::Message;
+use crate::prelude::rings_core::message::MessageCallback;
+use crate::prelude::rings_core::message::MessageHandler;
+use crate::prelude::rings_core::message::MessagePayload;
+use crate::prelude::rings_core::prelude::web3::types::Address;
+use crate::prelude::rings_core::session::AuthorizedInfo;
+use crate::prelude::rings_core::session::SessionManager;
+use crate::prelude::rings_core::session::Signer;
+use crate::prelude::rings_core::swarm::Swarm;
+use crate::prelude::rings_core::swarm::TransportManager;
+use crate::prelude::rings_core::transports::Transport;
+use crate::prelude::rings_core::types::ice_transport::IceTransport;
+use crate::prelude::rings_core::types::message::MessageListener;
+use crate::processor::Processor;
+use crate::processor::{self};
 
 #[wasm_bindgen]
 extern "C" {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,13 +1,12 @@
-use crate::{
-    jsonrpc::{
-        method::Method,
-        response::{Peer, TransportAndIce},
-    },
-    jsonrpc_client::SimpleClient,
-};
-use jsonrpc_core::{Params, Value};
+use jsonrpc_core::Params;
+use jsonrpc_core::Value;
 //use jsonrpc_core_client::RawClient;
 use serde_json::json;
+
+use crate::jsonrpc::method::Method;
+use crate::jsonrpc::response::Peer;
+use crate::jsonrpc::response::TransportAndIce;
+use crate::jsonrpc_client::SimpleClient;
 
 #[derive(Clone)]
 pub struct Client {

--- a/src/ethereum.rs
+++ b/src/ethereum.rs
@@ -1,5 +1,7 @@
+use anyhow::anyhow;
+use anyhow::Result;
+
 use crate::prelude::rings_core::prelude::web3;
-use anyhow::{anyhow, Result};
 
 pub type Transport = web3::transports::Either<web3::transports::WebSocket, web3::transports::Http>;
 

--- a/src/jsonrpc/method.rs
+++ b/src/jsonrpc/method.rs
@@ -1,6 +1,6 @@
 #![warn(missing_docs)]
-///! JSONRpc server supports methods.
-use crate::error::{Error, Result};
+use crate::error::Error;
+use crate::error::Result;
 
 /// supported methods.
 #[derive(Debug, Clone)]

--- a/src/jsonrpc/response.rs
+++ b/src/jsonrpc/response.rs
@@ -1,15 +1,16 @@
-use crate::{
-    error::{Error, Result},
-    prelude::rings_core::{
-        message::Encoded,
-        prelude::web3::{contract::tokens::Tokenizable, types::Address},
-        transports::Transport,
-    },
-    processor,
-};
-use serde::{Deserialize, Serialize};
-use serde_json::Value as JsonValue;
 use std::sync::Arc;
+
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json::Value as JsonValue;
+
+use crate::error::Error;
+use crate::error::Result;
+use crate::prelude::rings_core::message::Encoded;
+use crate::prelude::rings_core::prelude::web3::contract::tokens::Tokenizable;
+use crate::prelude::rings_core::prelude::web3::types::Address;
+use crate::prelude::rings_core::transports::Transport;
+use crate::processor;
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct Peer {

--- a/src/jsonrpc/server.rs
+++ b/src/jsonrpc/server.rs
@@ -1,13 +1,19 @@
 #![warn(missing_docs)]
-use super::{
-    method::Method,
-    response::{Peer, TransportAndIce},
-};
-use crate::{
-    error::Error as ServerError, prelude::rings_core::prelude::Address, processor::Processor,
-};
-use jsonrpc_core::{Error, ErrorCode, MetaIoHandler, Params, Result, Value};
 use std::str::FromStr;
+
+use jsonrpc_core::Error;
+use jsonrpc_core::ErrorCode;
+use jsonrpc_core::MetaIoHandler;
+use jsonrpc_core::Params;
+use jsonrpc_core::Result;
+use jsonrpc_core::Value;
+
+use super::method::Method;
+use super::response::Peer;
+use super::response::TransportAndIce;
+use crate::error::Error as ServerError;
+use crate::prelude::rings_core::prelude::Address;
+use crate::processor::Processor;
 
 pub(crate) async fn build_handler(handler: &mut MetaIoHandler<Processor>) {
     handler.add_method_with_meta(Method::ConnectPeerViaHttp.as_str(), connect_peer_via_http);

--- a/src/jsonrpc_client/client.rs
+++ b/src/jsonrpc_client/client.rs
@@ -4,10 +4,15 @@
 //! Sample:
 //! let client = Simpleclient::new(reqwest::Client::default(), "http://localhost:5000");
 //! client.call_method("test", params);
-use super::request::{parse_response, RequestBuilder};
-use crate::prelude::reqwest::Client as HttpClient;
-use jsonrpc_core::{Error, Params, Value};
 use std::sync::Arc;
+
+use jsonrpc_core::Error;
+use jsonrpc_core::Params;
+use jsonrpc_core::Value;
+
+use super::request::parse_response;
+use super::request::RequestBuilder;
+use crate::prelude::reqwest::Client as HttpClient;
 
 /// SimpleClient
 #[derive(Clone)]

--- a/src/jsonrpc_client/request.rs
+++ b/src/jsonrpc_client/request.rs
@@ -1,10 +1,20 @@
 #![warn(missing_docs)]
 //! Basic Request/Response structures used internally.
-use super::client::{CallMessage, NotifyMessage, RpcError};
-use jsonrpc_core::{Call, Error, Id, MethodCall, Notification, Params, Version};
+use jsonrpc_core::Call;
+use jsonrpc_core::Error;
+use jsonrpc_core::Id;
+use jsonrpc_core::MethodCall;
+use jsonrpc_core::Notification;
+use jsonrpc_core::Params;
+use jsonrpc_core::Version;
 use jsonrpc_pubsub::SubscriptionId;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 use serde_json::Value;
+
+use super::client::CallMessage;
+use super::client::NotifyMessage;
+use super::client::RpcError;
 
 /// Creates JSON-RPC requests
 pub struct RequestBuilder {

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,8 +1,11 @@
 use chrono::Local;
 use clap::ArgEnum;
+use log::Level;
+use log::LevelFilter;
 use log::Log;
-use log::{Level, Metadata, Record};
-use log::{LevelFilter, SetLoggerError};
+use log::Metadata;
+use log::Record;
+use log::SetLoggerError;
 
 pub struct Logger;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,9 +1,8 @@
 #[cfg(feature = "client")]
-pub use rings_core;
-#[cfg(feature = "browser")]
-pub use rings_core_wasm as rings_core;
-
-#[cfg(feature = "client")]
 pub use reqwest;
 #[cfg(feature = "browser")]
 pub use reqwest_wasm as reqwest;
+#[cfg(feature = "client")]
+pub use rings_core;
+#[cfg(feature = "browser")]
+pub use rings_core_wasm as rings_core;

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1,24 +1,30 @@
 #![warn(missing_docs)]
 //! Processor of rings-node jsonrpc-server.
-use crate::{
-    error::{Error, Result},
-    jsonrpc::{method, response::TransportAndIce},
-    jsonrpc_client::SimpleClient,
-    prelude::rings_core::{
-        message::{Encoded, Message, MessageHandler, PayloadSender},
-        prelude::{
-            uuid,
-            web3::{contract::tokens::Tokenizable, ethabi::Token, types::Address},
-            RTCSdpType,
-        },
-        swarm::{Swarm, TransportManager},
-        transports::Transport,
-        types::ice_transport::{IceTransport, IceTrickleScheme},
-    },
-};
+use std::str::FromStr;
+use std::sync::Arc;
+
 #[cfg(feature = "client")]
 use jsonrpc_core::Metadata;
-use std::{str::FromStr, sync::Arc};
+
+use crate::error::Error;
+use crate::error::Result;
+use crate::jsonrpc::method;
+use crate::jsonrpc::response::TransportAndIce;
+use crate::jsonrpc_client::SimpleClient;
+use crate::prelude::rings_core::message::Encoded;
+use crate::prelude::rings_core::message::Message;
+use crate::prelude::rings_core::message::MessageHandler;
+use crate::prelude::rings_core::message::PayloadSender;
+use crate::prelude::rings_core::prelude::uuid;
+use crate::prelude::rings_core::prelude::web3::contract::tokens::Tokenizable;
+use crate::prelude::rings_core::prelude::web3::ethabi::Token;
+use crate::prelude::rings_core::prelude::web3::types::Address;
+use crate::prelude::rings_core::prelude::RTCSdpType;
+use crate::prelude::rings_core::swarm::Swarm;
+use crate::prelude::rings_core::swarm::TransportManager;
+use crate::prelude::rings_core::transports::Transport;
+use crate::prelude::rings_core::types::ice_transport::IceTransport;
+use crate::prelude::rings_core::types::ice_transport::IceTrickleScheme;
 
 /// Processor for rings-node jsonrpc server
 #[derive(Clone)]
@@ -332,11 +338,13 @@ impl From<&(Address, Arc<Transport>)> for Peer {
 #[cfg(test)]
 #[cfg(feature = "client")]
 mod test {
-    use super::*;
-    use crate::prelude::rings_core::{
-        dht::PeerRing, ecc::SecretKey, prelude::uuid, session::SessionManager,
-    };
     use futures::lock::Mutex;
+
+    use super::*;
+    use crate::prelude::rings_core::dht::PeerRing;
+    use crate::prelude::rings_core::ecc::SecretKey;
+    use crate::prelude::rings_core::prelude::uuid;
+    use crate::prelude::rings_core::session::SessionManager;
 
     fn new_processor() -> Processor {
         let key = SecretKey::random();

--- a/src/service/http_error.rs
+++ b/src/service/http_error.rs
@@ -1,7 +1,6 @@
-use axum::{
-    http::StatusCode,
-    response::{IntoResponse, Response},
-};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::response::Response;
 
 #[derive(Debug)]
 pub enum HttpError {

--- a/src/service/is_turn.rs
+++ b/src/service/is_turn.rs
@@ -1,14 +1,16 @@
-use turn::auth::*;
-use turn::relay::relay_static::*;
-use turn::server::{config::*, *};
-use turn::Error;
-
 use std::collections::HashMap;
-use std::net::{IpAddr, SocketAddr};
+use std::net::IpAddr;
+use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::Arc;
+
 use tokio::net::UdpSocket;
 use tokio::time::Duration;
+use turn::auth::*;
+use turn::relay::relay_static::*;
+use turn::server::config::*;
+use turn::server::*;
+use turn::Error;
 use webrtc_util::vnet::net::*;
 
 struct AuthBuilder {

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -4,18 +4,23 @@ mod http_error;
 #[cfg(feature = "daemon")]
 mod is_turn;
 
-use self::http_error::HttpError;
-use crate::{
-    prelude::rings_core::{message::MessageHandler, swarm::Swarm},
-    processor::Processor,
-};
-use axum::{extract::Extension, response::IntoResponse, routing::post, Router};
-use http::header::{self, HeaderValue};
+use std::sync::Arc;
+
+use axum::extract::Extension;
+use axum::response::IntoResponse;
+use axum::routing::post;
+use axum::Router;
+use http::header::HeaderValue;
+use http::header::{self};
 #[cfg(feature = "daemon")]
 pub use is_turn::run_udp_turn;
 use jsonrpc_core::MetaIoHandler;
-use std::sync::Arc;
 use tower_http::cors::CorsLayer;
+
+use self::http_error::HttpError;
+use crate::prelude::rings_core::message::MessageHandler;
+use crate::prelude::rings_core::swarm::Swarm;
+use crate::processor::Processor;
 
 /// Run a web server to handle jsonrpc request
 pub async fn run_service(


### PR DESCRIPTION
Set down more style constraints in `rustfmt.toml`. You will never worry about the layouts of auto imported `use` with that  : )
```toml
edition = "2021"
reorder_imports = true
imports_granularity = "Item"
group_imports = "StdExternalCrate"
where_single_line = true
trailing_comma = "Vertical"
report_fixme = "Unnumbered"
overflow_delimited_expr = true
```