### PR TITLE
add build_version for browser

### DIFF
--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -613,3 +613,33 @@ impl TryFrom<&TransportAndIce> for JsValue {
         JsValue::from_serde(value).map_err(JsError::from)
     }
 }
+
+#[wasm_bindgen]
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+/// Internal Info struct
+pub struct InternalInfo {
+    build_version: String,
+}
+
+#[wasm_bindgen]
+impl InternalInfo {
+    /// Get InternalInfo
+    fn build() -> Self {
+        Self {
+            build_version: crate::util::build_version(),
+        }
+    }
+
+    /// build_version getter
+    #[wasm_bindgen(getter)]
+    pub fn build_version(&self) -> String {
+        self.build_version.clone()
+    }
+}
+
+/// Build InternalInfo
+#[wasm_bindgen]
+pub fn internal_info() -> InternalInfo {
+    InternalInfo::build()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,3 +149,4 @@ pub mod prelude;
 pub mod processor;
 #[cfg(feature = "client")]
 pub mod service;
+pub mod util;

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -98,26 +98,15 @@ async fn node_info_header<B>(
     let mut res = next.run(req).await;
     let headers = res.headers_mut();
 
-    if let Ok(version) = axum::http::HeaderValue::from_str(build_version().as_str()) {
+    if let Ok(version) = axum::http::HeaderValue::from_str(crate::util::build_version().as_str()) {
         headers.insert("X-NODE-VERSION", version);
     }
     res
 }
 
-fn build_version() -> String {
-    let mut infos = vec![];
-    if let Some(version) = option_env!("CARGO_PKG_VERSION") {
-        infos.push(version);
-    };
-    if let Some(git_hash) = option_env!("GIT_SHORT_HASH") {
-        infos.push(git_hash);
-    }
-    infos.join("-")
-}
-
 async fn status_handler() -> Result<axum::extract::Json<serde_json::Value>, HttpError> {
     Ok(axum::extract::Json(serde_json::json!({
-        "node_version": build_version()
+        "node_version": crate::util::build_version()
     })))
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,14 @@
+#![warn(missing_docs)]
+//! Utils for project.
+
+/// build_version of program
+pub fn build_version() -> String {
+    let mut infos = vec![];
+    if let Some(version) = option_env!("CARGO_PKG_VERSION") {
+        infos.push(version);
+    };
+    if let Some(git_hash) = option_env!("GIT_SHORT_HASH") {
+        infos.push(git_hash);
+    }
+    infos.join("-")
+}


### PR DESCRIPTION
## How to use
```typescript
import { internal_info } from 'rings-node'
const info = internal_info()
console.log(`build_version: ${info.build_version}`)
```
