### PR TITLE
handshake info should be encoded

### DIFF
--- a/node/bin/rings.rs
+++ b/node/bin/rings.rs
@@ -426,7 +426,7 @@ async fn daemon_run(args: RunCommand) -> anyhow::Result<()> {
     let processor_clone = processor.clone();
 
     let pubkey = Arc::new(key.pubkey());
-    println!("Signautre: {}", Processor::generate_signature(&key));
+    println!("Signature: {}", Processor::generate_signature(&key));
 
     let bind_addr = get_value(args.http_addr, c.http_addr);
 

--- a/node/src/jsonrpc/server.rs
+++ b/node/src/jsonrpc/server.rs
@@ -20,7 +20,6 @@ use crate::prelude::jsonrpc_core::Params;
 use crate::prelude::jsonrpc_core::Result;
 use crate::prelude::jsonrpc_core::Value;
 use crate::prelude::rings_core::dht::Did;
-
 use crate::prelude::rings_core::message::Decoder;
 use crate::prelude::rings_core::message::Encoded;
 use crate::prelude::rings_core::message::Encoder;


### PR DESCRIPTION
Handshake info should be encoded with base58, To make it easier for manual creation and copying/pasting of handshake information 