### PR TITLE
Make config file forward compat

### DIFF
--- a/node/src/backend/extension.rs
+++ b/node/src/backend/extension.rs
@@ -49,7 +49,7 @@ use crate::prelude::reqwest;
 use crate::prelude::*;
 
 /// Path of a wasm extension
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub enum Path {
     /// Local filesystem path
     Local(String),
@@ -58,7 +58,7 @@ pub enum Path {
 }
 
 /// Configure for Extension
-#[derive(Deserialize, Serialize, Debug, Clone, Default)]
+#[derive(Deserialize, Serialize, Debug, Clone, Default, PartialEq, Eq)]
 pub struct ExtensionConfig {
     /// Path of extension, can be remote or local
     pub paths: Vec<Path>,

--- a/node/src/backend/service/http_server.rs
+++ b/node/src/backend/service/http_server.rs
@@ -19,7 +19,7 @@ use crate::prelude::rings_rpc::types::HttpRequest;
 use crate::prelude::*;
 
 /// HTTP Server Config, specific determine port.
-#[derive(Deserialize, Clone, Serialize, Debug)]
+#[derive(Deserialize, Clone, Serialize, Debug, PartialEq, Eq)]
 pub struct HiddenServerConfig {
     /// name of hidden service
     pub name: String,

--- a/node/src/config/mod.rs
+++ b/node/src/config/mod.rs
@@ -141,3 +141,29 @@ impl StorageConfig {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deserialization_with_missed_field() {
+        let yaml = r#"
+bind: 127.0.0.1:50000
+endpoint_url: http://127.0.0.1:50000
+ecdsa_key: 65860affb4b570dba06db294aa7c676f68e04a5bf2721243ad3cbc05a79c68c0
+ice_servers: stun://stun.l.google.com:19302
+stabilize_timeout: 3
+external_ip: null
+data_storage:
+  path: /Users/foo/.rings/data
+  capacity: 200000000
+measure_storage:
+  path: /Users/foo/.rings/measure
+  capacity: 200000000
+"#;
+        let cfg: Config = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(cfg.extension, ExtensionConfig::default());
+        assert_eq!(cfg.backend, vec![]);
+    }
+}

--- a/node/src/config/mod.rs
+++ b/node/src/config/mod.rs
@@ -48,9 +48,15 @@ pub struct Config {
     pub ice_servers: String,
     pub stabilize_timeout: usize,
     pub external_ip: Option<String>,
+    /// When there is no configuration in the YAML file,
+    /// its deserialization is equivalent to `vec![]` in Rust.
+    #[serde(default)]
     pub backend: Vec<HiddenServerConfig>,
     pub data_storage: StorageConfig,
     pub measure_storage: StorageConfig,
+    /// When there is no configuration in the YAML file,
+    /// its deserialization is equivalent to `ExtensionConfig(vec![])` in Rust.
+    #[serde(default)]
     pub extension: ExtensionConfig,
 }
 


### PR DESCRIPTION
For now, you can ignore the below field in `config.yaml`:

* backend: default value: []
* extension: default value: Path []
