### PR TITLE
chore: clean cargo config file

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,2 @@
-[alias]
-build-node= "build --features node --no-default-features"
-build-browser-pack = "build --lib --target=wasm32-unknown-unknown --features browser --no-default-features"
-test-browser = "test --target=wasm32-unknown-unknown --features browser --no-default-features"
-
 [target.wasm32-unknown-unknown]
 runner = 'wasm-bindgen-test-runner'

--- a/core/.cargo/config.toml
+++ b/core/.cargo/config.toml
@@ -1,6 +1,0 @@
-[target.wasm32-unknown-unknown]
-runner = 'wasm-bindgen-test-runner'
-
-[alias]
-wasm = "build -p rings-core --target=wasm32-unknown-unknown --features wasm --no-default-features"
-test-wasm = "test -p rings-core --target=wasm32-unknown-unknown --features wasm --no-default-features"


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## :large_blue_circle: What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
This PR remove not using cargo configs.

## :brown_circle: What is the current behavior? (You can also link to an open issue here)
There are some unused alias options in the config.
There is also a redundant config file in the core directory.

## :green_circle: What is the new behavior (if this is a feature change)?
Those alias configs are removed. That redundant config file is removed.
No new behavior.

## :radioactive: Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.

## :information_source: Other information

Closes #issue
