### PR TITLE
release: 0.2.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ members = ["core", "node", "rpc", "derive"]
 resolver = "2"
 
 [workspace.dependencies]
-rings-core = { version = "0.2.5", path = "core", default-features = false }
+rings-core = { version = "0.2.6", path = "core", default-features = false }
 rings-derive = { version = "0.1.0", path = "derive", default-features = false }
-rings-rpc = { version = "0.2.5", path = "rpc", default-features = false }
+rings-rpc = { version = "0.2.6", path = "rpc", default-features = false }
 wasm-bindgen = { version = "0.2.84" }
 wasm-bindgen-macro-support = { version = "0.2.84" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 
 [workspace.dependencies]
 rings-core = { version = "0.2.6", path = "core", default-features = false }
-rings-derive = { version = "0.1.0", path = "derive", default-features = false }
+rings-derive = { version = "0.2.6", path = "derive", default-features = false }
 rings-rpc = { version = "0.2.6", path = "rpc", default-features = false }
 wasm-bindgen = { version = "0.2.84" }
 wasm-bindgen-macro-support = { version = "0.2.84" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rings-core"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 authors = ["RND <dev@ringsnetwork.io>"]
 description = "Chord DHT implementation with ICE"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rings-derive"
-version = "0.1.0"
+version = "0.2.6"
 edition = "2021"
 authors = ["RND <dev@ringsnetwork.io>"]
 repository = "https://github.com/RingsNetwork/rings-node"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -7,7 +7,6 @@ repository = "https://github.com/RingsNetwork/rings-node"
 license = "GPL-3.0"
 description = "Helper macros for rings node implementation."
 
-
 [lib]
 proc-macro = true
 

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2021"
 authors = ["RND <dev@ringsnetwork.io>"]
 repository = "https://github.com/RingsNetwork/rings-node"
 license = "GPL-3.0"
+description = "Helper macros for rings node implementation."
+
 
 [lib]
 proc-macro = true

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rings-node"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 default-run = "rings"
 authors = ["RND <dev@ringsnetwork.io>"]

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rings-rpc"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 authors = ["RND <dev@ringsnetwork.io>"]
 description = """


### PR DESCRIPTION
Release 0.2.6 (node, core)

Related PRs, only showing breaking change and new features.

```
refactor!: Initialize SessionManager with builder pattern (#436)
feat!: Support loading wasm/wat as background extension (#432)
feat!: Encode handshake info (#430)
refactor!: Split swarm from message handler using events (#420)
refactor!: Add rings-rpc module (#409)
feat!: Set data to be redundant (#419)
feat!: Add bip137, and support verification with bitcoin (#411)
feat: Inspect storage (#389)
refactor!: Use global `this` for browser environment (#382)
feat: Add inspect API (#368, #369, #389)
```
