### PR TITLE
feature: get transport connection stats

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -118,6 +118,7 @@ web-sys = { version = "0.3.56", optional = true, features = [
     "RtcIceGatheringState",
     "RtcIceCredentialType",
     "RtcLifecycleEvent",
+    "RtcStatsReport",
     "console",
     "Blob",
 ] }

--- a/core/src/transports/default/transport.rs
+++ b/core/src/transports/default/transport.rs
@@ -223,6 +223,20 @@ impl IceTransportInterface<TransportEvent, AcChannel<TransportEvent>> for Defaul
             .map(|pc| pc.ice_connection_state())
     }
 
+    async fn get_stats(&self) -> Option<Vec<String>> {
+        let pc = self.get_peer_connection().await?;
+        let reports = pc.get_stats().await.reports;
+
+        Some(
+            reports
+                .into_iter()
+                .map(|x| {
+                    serde_json::to_string(&x).unwrap_or("failed to dump stats entry".to_string())
+                })
+                .collect(),
+        )
+    }
+
     async fn is_disconnected(&self) -> bool {
         matches!(
             self.ice_connection_state().await,

--- a/core/src/transports/dummy/transport.rs
+++ b/core/src/transports/dummy/transport.rs
@@ -106,6 +106,10 @@ impl IceTransportInterface<TransportEvent, AcChannel<TransportEvent>> for DummyT
         *self.ice_connection_state.lock().unwrap()
     }
 
+    async fn get_stats(&self) -> Option<Vec<String>> {
+        None
+    }
+
     async fn is_disconnected(&self) -> bool {
         matches!(
             self.ice_connection_state().await,

--- a/core/src/types/ice_transport/mod.rs
+++ b/core/src/types/ice_transport/mod.rs
@@ -63,6 +63,7 @@ pub trait IceTransportInterface<E: Send, Ch: Channel<E>> {
     async fn apply_callback(&self) -> Result<&Self>;
     async fn close(&self) -> Result<()>;
     async fn ice_connection_state(&self) -> Option<Self::IceConnectionState>;
+    async fn get_stats(&self) -> Option<Vec<String>>;
     async fn is_connected(&self) -> bool;
     async fn is_disconnected(&self) -> bool;
     async fn send_message(&self, msg: &Bytes) -> Result<()>;


### PR DESCRIPTION
I found that this API provides information similar to `chrome://webrtc-internals` when attempting to resolve issue #445.
It is particularly helpful when you are not working within the Chrome UI.

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

## :large_blue_circle: What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
This PR export `get_stats` method of `RtcPeerConnection` to `Transport`, allowing for easy data manipulation through json serialization.

## :brown_circle: What is the current behavior? (You can also link to an open issue here)
Cannot inspect transport stats. Can only get its connection state.

## :green_circle: What is the new behavior (if this is a feature change)?
Can get stats by invoke `get_sats` method of `Transport`.

## :radioactive: Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No breaking change.

## :information_source: Other information
The docs of RTCPeerConnection.get_stats method: https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/getStats

Closes #issue
