### PR TITLE
feat: limit connection by measurement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -352,7 +352,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -363,7 +363,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -708,7 +708,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -1070,7 +1070,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -1092,7 +1092,7 @@ checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
  "darling_core 0.20.1",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -1235,7 +1235,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -1369,7 +1369,7 @@ dependencies = [
  "darling 0.20.1",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -1594,7 +1594,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -2737,7 +2737,7 @@ checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -2847,9 +2847,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
@@ -2876,9 +2876,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -3260,7 +3260,9 @@ dependencies = [
 name = "rings-derive"
 version = "0.2.6"
 dependencies = [
+ "proc-macro2",
  "quote",
+ "syn 2.0.27",
  "wasm-bindgen-macro-support",
  "wasmer",
 ]
@@ -3622,7 +3624,7 @@ checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -3892,9 +3894,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3948,7 +3950,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -4072,7 +4074,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -4217,7 +4219,7 @@ checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -5364,5 +5366,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
 ]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -78,7 +78,7 @@ tracing = "0.1.37"
 url = { version = "2", features = ["serde"] }
 
 futures = { version = "0.3.21", default-features = false, optional = true }
-rings-derive = { workspace = true, optional = true }
+rings-derive = { workspace = true, optional = true, features = ["core_crate"] }
 uuid = { version = "0.8.2", optional = true }
 web3 = { version = "0.18.0", default-features = false, optional = true }
 

--- a/core/src/dht/finger.rs
+++ b/core/src/dht/finger.rs
@@ -72,7 +72,7 @@ impl FingerTable {
             return;
         }
         if did == self.did {
-            tracing::info!("set finger table with self did, ignore it");
+            tracing::trace!("set finger table with self did, ignore it");
             return;
         }
         self.finger[index] = Some(did);

--- a/core/src/dht/stabilization.rs
+++ b/core/src/dht/stabilization.rs
@@ -86,7 +86,7 @@ impl Stabilization {
         });
         if self.chord.did != successor_min {
             for s in successor_list {
-                tracing::info!("STABILIZATION notify_predecessor: {:?}", s);
+                tracing::debug!("STABILIZATION notify_predecessor: {:?}", s);
                 let payload = MessagePayload::new_send(
                     msg.clone(),
                     self.swarm.session_manager(),
@@ -110,7 +110,7 @@ impl Stabilization {
                     closest_predecessor,
                     PeerRingRemoteAction::FindSuccessorForFix(finger_did),
                 ) => {
-                    tracing::info!("STABILIZATION fix_fingers: {:?}", finger_did);
+                    tracing::debug!("STABILIZATION fix_fingers: {:?}", finger_did);
                     let msg = Message::FindSuccessorSend(FindSuccessorSend {
                         did: finger_did,
                         then: FindSuccessorThen::Report(FindSuccessorReportHandler::FixFingerTable),

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -160,8 +160,11 @@ pub enum Error {
     #[error("Cannot seek did in swarm table, {0}")]
     SwarmMissDidInTable(crate::dht::Did),
 
-    #[error("Cannot gather local candidate")]
-    FailedOnGatherLocalCandidate,
+    #[error("Cannot gather local candidate, {0}")]
+    FailedOnGatherLocalCandidate(String),
+
+    #[error("Node behaviour bad")]
+    NodeBehaviourBad(crate::dht::Did),
 
     #[error("Cannot get transport from did: {0}")]
     SwarmMissTransport(crate::dht::Did),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -58,7 +58,6 @@
 //! ```shell
 //! cargo build -p rings-core --target=wasm32-unknown-unknown --features wasm --no-default-features
 //! ```
-
 pub mod channels;
 pub mod dht;
 pub mod ecc;

--- a/core/src/measure.rs
+++ b/core/src/measure.rs
@@ -53,6 +53,10 @@ pub trait ConnectBehaviour<const THRESHOLD: i16>: Measure {
     async fn good(&self, did: Did) -> bool {
         let conn = self.get_count(did, MeasureCounter::Connect).await;
         let disconn = self.get_count(did, MeasureCounter::Disconnected).await;
+	tracing::debug!(
+	    "[ConnectBehaviour] in Threadhold: {:}, connect: {:}, disconn: {:}, delta: {:}",
+	    THRESHOLD,
+	    conn, disconn, conn - disconn);
         ((conn - disconn) as i16) < THRESHOLD
     }
 }

--- a/core/src/measure.rs
+++ b/core/src/measure.rs
@@ -53,10 +53,13 @@ pub trait ConnectBehaviour<const THRESHOLD: i16>: Measure {
     async fn good(&self, did: Did) -> bool {
         let conn = self.get_count(did, MeasureCounter::Connect).await;
         let disconn = self.get_count(did, MeasureCounter::Disconnected).await;
-	tracing::debug!(
-	    "[ConnectBehaviour] in Threadhold: {:}, connect: {:}, disconn: {:}, delta: {:}",
-	    THRESHOLD,
-	    conn, disconn, conn - disconn);
+        tracing::debug!(
+            "[ConnectBehaviour] in Threadhold: {:}, connect: {:}, disconn: {:}, delta: {:}",
+            THRESHOLD,
+            conn,
+            disconn,
+            conn - disconn
+        );
         ((conn - disconn) as i16) < THRESHOLD
     }
 }

--- a/core/src/measure.rs
+++ b/core/src/measure.rs
@@ -16,6 +16,10 @@ pub enum MeasureCounter {
     Received,
     /// The number of failed to receive messages.
     FailedToReceive,
+    /// The number of connected.
+    Connect,
+    /// The number of disconnect.
+    Disconnected,
 }
 
 /// `Measure` is used to assess the reliability of peers by counting their behaviour.
@@ -28,4 +32,55 @@ pub trait Measure {
     async fn incr(&self, did: Did, counter: MeasureCounter);
     /// `get_count` returns the counter of the given peer.
     async fn get_count(&self, did: Did, counter: MeasureCounter) -> u64;
+}
+
+/// `BehaviourJudgement` trait defines a method `good` for assessing whether a node behaves well.
+/// Any structure implementing this trait should provide a way to measure the "goodness" of a node.
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
+pub trait BehaviourJudgement: Measure {
+    /// This asynchronous method should return a boolean indicating whether the node identified by `did` is behaving well.
+    async fn good(&self, did: Did) -> bool;
+}
+
+/// `ConnectBehaviour` trait offers a default implementation for the `good` method, providing a judgement
+/// based on a node's behavior in establishing connections.
+/// The "goodness" of a node is measured by comparing the connection and disconnection counts against a given threshold.
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
+pub trait ConnectBehaviour<const THRESHOLD: i16>: Measure {
+    /// This asynchronous method returns a boolean indicating whether the node identified by `did` has a satisfactory connection behavior.
+    async fn good(&self, did: Did) -> bool {
+        let conn = self.get_count(did, MeasureCounter::Connect).await;
+        let disconn = self.get_count(did, MeasureCounter::Disconnected).await;
+        ((conn - disconn) as i16) < THRESHOLD
+    }
+}
+
+/// `MessageSendBehaviour` trait provides a default implementation for the `good` method, judging a node's
+/// behavior based on its message sending capabilities.
+/// The "goodness" of a node is measured by comparing the sent and failed-to-send counts against a given threshold.
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
+pub trait MessageSendBehaviour<const THRESHOLD: i16>: Measure {
+    /// This asynchronous method returns a boolean indicating whether the node identified by `did` has a satisfactory message sending behavior.
+    async fn good(&self, did: Did) -> bool {
+        let sent = self.get_count(did, MeasureCounter::Sent).await;
+        let failed = self.get_count(did, MeasureCounter::FailedToSend).await;
+        ((failed - sent) as i16) < THRESHOLD
+    }
+}
+
+/// `MessageRecvBehaviour` trait provides a default implementation for the `good` method, assessing a node's
+/// behavior based on its message receiving capabilities.
+/// The "goodness" of a node is measured by comparing the received and failed-to-receive counts against a given threshold.
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
+pub trait MessageRecvBehaviour<const THRESHOLD: i16>: Measure {
+    /// This asynchronous method returns a boolean indicating whether the node identified by `did` has a satisfactory message receiving behavior.
+    async fn good(&self, did: Did) -> bool {
+        let recv = self.get_count(did, MeasureCounter::Received).await;
+        let failed = self.get_count(did, MeasureCounter::FailedToReceive).await;
+        ((failed - recv) as i16) < THRESHOLD
+    }
 }

--- a/core/src/measure.rs
+++ b/core/src/measure.rs
@@ -72,9 +72,8 @@ pub trait ConnectBehaviour<const THRESHOLD: i16>: Measure {
 pub trait MessageSendBehaviour<const THRESHOLD: i16>: Measure {
     /// This asynchronous method returns a boolean indicating whether the node identified by `did` has a satisfactory message sending behavior.
     async fn good(&self, did: Did) -> bool {
-        let sent = self.get_count(did, MeasureCounter::Sent).await;
         let failed = self.get_count(did, MeasureCounter::FailedToSend).await;
-        ((failed - sent) as i16) < THRESHOLD
+        (failed as i16) < THRESHOLD
     }
 }
 
@@ -86,8 +85,7 @@ pub trait MessageSendBehaviour<const THRESHOLD: i16>: Measure {
 pub trait MessageRecvBehaviour<const THRESHOLD: i16>: Measure {
     /// This asynchronous method returns a boolean indicating whether the node identified by `did` has a satisfactory message receiving behavior.
     async fn good(&self, did: Did) -> bool {
-        let recv = self.get_count(did, MeasureCounter::Received).await;
         let failed = self.get_count(did, MeasureCounter::FailedToReceive).await;
-        ((failed - recv) as i16) < THRESHOLD
+        (failed as i16) < THRESHOLD
     }
 }

--- a/core/src/storage/persistence/kv.rs
+++ b/core/src/storage/persistence/kv.rs
@@ -130,7 +130,7 @@ impl PersistenceStorageOperation for KvStorage {
 #[async_trait]
 impl<K, V, I> PersistenceStorageReadAndWrite<K, V> for I
 where
-    K: ToString + FromStr + std::marker::Sync + Send,
+    K: ToString + FromStr + std::marker::Sync + Send + std::fmt::Debug,
     V: DeserializeOwned + serde::Serialize + std::marker::Sync + Send,
     I: PersistenceStorageOperation + std::marker::Sync + KvStorageBasic,
 {
@@ -152,7 +152,7 @@ where
     async fn put(&self, key: &K, value: &V) -> Result<()> {
         self.prune().await?;
         let data = bincode::serialize(value).map_err(Error::BincodeSerialize)?;
-        println!("insert v: {:?}", data);
+        tracing::debug!("Try inserting key: {:?}", key);
         self.get_db()
             .insert(key.to_string().as_bytes(), data)
             .map_err(Error::SledError)?;

--- a/core/src/swarm/impls.rs
+++ b/core/src/swarm/impls.rs
@@ -308,7 +308,7 @@ impl manager::Judegement for Swarm {
     /// Record a succeeded connected
     async fn record_connect(&self, did: Did) {
         if let Some(measure) = &self.measure {
-	    tracing::info!("[Judgement] Record connect");
+            tracing::info!("[Judgement] Record connect");
             measure.incr(did, MeasureCounter::Connect).await;
         }
     }
@@ -316,7 +316,7 @@ impl manager::Judegement for Swarm {
     /// Record a disconnected
     async fn record_disconnected(&self, did: Did) {
         if let Some(measure) = &self.measure {
-	    tracing::info!("[Judgement] Record disconnected");
+            tracing::info!("[Judgement] Record disconnected");
             measure.incr(did, MeasureCounter::Disconnected).await;
         }
     }

--- a/core/src/swarm/mod.rs
+++ b/core/src/swarm/mod.rs
@@ -384,7 +384,7 @@ impl Swarm {
             return Err(Error::NodeBehaviourBad(did));
         }
         tracing::info!("Try connect Did {:?}", &did);
-	self.record_connect(did).await;
+        self.record_connect(did).await;
         let (transport, offer_msg) = self.prepare_transport_offer().await?;
 
         self.send_message(Message::ConnectNodeSend(offer_msg), did)
@@ -402,7 +402,7 @@ impl Swarm {
             return Err(Error::NodeBehaviourBad(did));
         }
         tracing::info!("Try connect Did {:?} via {:?}", &did, &next_hop);
-	self.record_connect(did).await;
+        self.record_connect(did).await;
         let (transport, offer_msg) = self.prepare_transport_offer().await?;
 
         self.send_message_by_hop(Message::ConnectNodeSend(offer_msg), did, next_hop)

--- a/core/src/swarm/mod.rs
+++ b/core/src/swarm/mod.rs
@@ -12,6 +12,7 @@ use std::sync::Mutex;
 use async_recursion::async_recursion;
 use async_trait::async_trait;
 pub use builder::SwarmBuilder;
+use rings_derive::JudgeConnection;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 pub use types::MeasureImpl;
@@ -45,6 +46,7 @@ use crate::types::ice_transport::IceTransportInterface;
 use crate::types::ice_transport::IceTrickleScheme;
 
 /// The transports and dht management.
+#[derive(JudgeConnection)]
 pub struct Swarm {
     /// A list to for store and manage pending_transport.
     pub(crate) pending_transports: Mutex<Vec<Arc<Transport>>>,
@@ -364,51 +366,19 @@ impl Swarm {
     /// 2) remove from transport pool;
     /// 3) close the transport connection;
     pub async fn disconnect(&self, did: Did) -> Result<()> {
-        self.record_disconnected(did).await;
-        tracing::info!("[disconnect] removing from DHT {:?}", did);
-        self.dht.remove(did)?;
-        if let Some((_address, trans)) = self.remove_transport(did) {
-            trans.close().await?
-        }
-        Ok(())
+        JudgeConnection::disconnect(self, did).await
     }
 
     /// Connect a given Did. It the did is managed by swarm transport pool, return directly,
     /// else try prepare offer and establish connection by dht.
     /// This function may returns a pending transport or connected transport.
     pub async fn connect(&self, did: Did) -> Result<Arc<Transport>> {
-        if let Some(t) = self.get_and_check_transport(did).await {
-            return Ok(t);
-        }
-        if !self.behaviour_good(did).await {
-            return Err(Error::NodeBehaviourBad(did));
-        }
-        tracing::info!("Try connect Did {:?}", &did);
-        self.record_connect(did).await;
-        let (transport, offer_msg) = self.prepare_transport_offer().await?;
-
-        self.send_message(Message::ConnectNodeSend(offer_msg), did)
-            .await?;
-
-        Ok(transport)
+        JudgeConnection::connect(self, did).await
     }
 
     /// Similar to connect, but this function will try connect a Did by given hop.
     pub async fn connect_via(&self, did: Did, next_hop: Did) -> Result<Arc<Transport>> {
-        if let Some(t) = self.get_and_check_transport(did).await {
-            return Ok(t);
-        }
-        if !self.behaviour_good(did).await {
-            return Err(Error::NodeBehaviourBad(did));
-        }
-        tracing::info!("Try connect Did {:?} via {:?}", &did, &next_hop);
-        self.record_connect(did).await;
-        let (transport, offer_msg) = self.prepare_transport_offer().await?;
-
-        self.send_message_by_hop(Message::ConnectNodeSend(offer_msg), did, next_hop)
-            .await?;
-
-        Ok(transport)
+        JudgeConnection::connect_via(self, did, next_hop).await
     }
 
     /// Check the status of swarm

--- a/core/src/swarm/types.rs
+++ b/core/src/swarm/types.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 
 use crate::dht::Did;
 use crate::dht::LiveDid;
-use crate::measure::Measure;
+use crate::measure::BehaviourJudgement;
 use crate::swarm::Swarm;
 use crate::transports::manager::TransportManager;
 use crate::transports::Transport;
@@ -15,11 +15,11 @@ use crate::types::ice_transport::IceTransportInterface;
 
 /// Type of Measure, see [Measure].
 #[cfg(not(feature = "wasm"))]
-pub type MeasureImpl = Box<dyn Measure + Send + Sync>;
+pub type MeasureImpl = Box<dyn BehaviourJudgement + Send + Sync>;
 
 /// Type of Measure, see [Measure].
 #[cfg(feature = "wasm")]
-pub type MeasureImpl = Box<dyn Measure>;
+pub type MeasureImpl = Box<dyn BehaviourJudgement>;
 
 /// WrappedDid is a DID wrapped by Swarm and bound to a weak reference of a Transport,
 /// which enables checking whether the WrappedDid is live or not.

--- a/core/src/transports/default/transport.rs
+++ b/core/src/transports/default/transport.rs
@@ -469,7 +469,7 @@ impl IceTrickleScheme for DefaultTransport {
             .map(|c| c.clone().to_json().unwrap().into())
             .collect::<Vec<_>>();
         if local_candidates_json.is_empty() {
-            return Err(Error::FailedOnGatherLocalCandidate);
+            return Err(Error::FailedOnGatherLocalCandidate(kind.to_string()));
         }
         let data = HandshakeInfo {
             sdp: serde_json::to_string(&sdp).unwrap(),

--- a/core/src/transports/manager.rs
+++ b/core/src/transports/manager.rs
@@ -98,7 +98,7 @@ pub trait JudgeConnection: Judegement + ConnectionManager {
     /// Asynchronously disconnects the transport associated with the provided DID after recording the disconnection.
     async fn disconnect(&self, did: Did) -> Result<()> {
         self.record_disconnected(did).await;
-	tracing::debug!("[JudegeConnection] Disconnected {:?}", &did);
+        tracing::debug!("[JudegeConnection] Disconnected {:?}", &did);
         ConnectionManager::disconnect(self, did).await
     }
 
@@ -107,7 +107,7 @@ pub trait JudgeConnection: Judegement + ConnectionManager {
         if !self.should_connect(did).await {
             return Err(Error::NodeBehaviourBad(did));
         }
-	tracing::debug!("[JudgeConnection] Try Connect {:?}", &did);
+        tracing::debug!("[JudgeConnection] Try Connect {:?}", &did);
         self.record_connect(did).await;
         ConnectionManager::connect(self, did).await
     }
@@ -117,7 +117,7 @@ pub trait JudgeConnection: Judegement + ConnectionManager {
         if !self.should_connect(did).await {
             return Err(Error::NodeBehaviourBad(did));
         }
-	tracing::debug!("[JudgeConnection] Try Connect {:?}", &did);
+        tracing::debug!("[JudgeConnection] Try Connect {:?}", &did);
         self.record_connect(did).await;
         ConnectionManager::connect_via(self, did, next_hop).await
     }

--- a/core/src/transports/wasm/transport.rs
+++ b/core/src/transports/wasm/transport.rs
@@ -549,7 +549,7 @@ impl IceTrickleScheme for WasmTransport {
             .collect();
 
         if local_candidates_json.is_empty() {
-            return Err(Error::FailedOnGatherLocalCandidate(kind.to_string()));
+            return Err(Error::FailedOnGatherLocalCandidate(format!("{:?}", kind)));
         }
 
         let data = HandshakeInfo {

--- a/core/src/transports/wasm/transport.rs
+++ b/core/src/transports/wasm/transport.rs
@@ -549,7 +549,7 @@ impl IceTrickleScheme for WasmTransport {
             .collect();
 
         if local_candidates_json.is_empty() {
-            return Err(Error::FailedOnGatherLocalCandidate);
+            return Err(Error::FailedOnGatherLocalCandidate(kind.to_string()));
         }
 
         let data = HandshakeInfo {

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -11,13 +11,16 @@ description = "Helper macros for rings node implementation."
 proc-macro = true
 
 [features]
-default = []
+core_crate = []
+default = [
+]
 wasm = [
     "wasm-bindgen-macro-support",
-    "quote",
 ]
 
 [dependencies]
-quote = { version = "1.0.28", optional = true }
+proc-macro2 = "1.0.66"
+quote = "1.0.32"
+syn = "2.0.27"
 wasm-bindgen-macro-support = { workspace = true, optional = true }
 wasmer = { version = "3.3.0", optional = true }

--- a/derive/src/derives.rs
+++ b/derive/src/derives.rs
@@ -16,7 +16,7 @@ pub fn impl_measure_behaviour_traits(ast: &syn::DeriveInput) -> proc_macro2::Tok
     #[cfg(not(feature = "core_crate"))]
     quote! {
     use rings_core::measure::measure::MessageRecvBehaviour;
-    use rings_core::measure::measure::MessageSendehaviour;
+    use rings_core::measure::measure::MessageSendBehaviour;
     use rings_core::measure::measure::ConnectBehaviour;
 
     #impl_token

--- a/derive/src/derives.rs
+++ b/derive/src/derives.rs
@@ -1,0 +1,53 @@
+pub fn impl_measure_behaviour_traits(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
+    let name = &ast.ident;
+
+    let impl_token = quote! {
+    #[cfg_attr(feature = "node", async_trait)]
+    #[cfg_attr(feature = "browser", async_trait(?Send))]
+    impl<const T: i16> MessageSendBehaviour<T> for #name {}
+    #[cfg_attr(feature = "node", async_trait)]
+    #[cfg_attr(feature = "browser", async_trait(?Send))]
+    impl<const T: i16> MessageRecvBehaviour<T> for #name {}
+    #[cfg_attr(feature = "node", async_trait)]
+    #[cfg_attr(feature = "browser", async_trait(?Send))]
+    impl<const T: i16> ConnectBehaviour<T> for #name {}
+    };
+
+    #[cfg(not(feature = "core_crate"))]
+    quote! {
+    use rings_core::measure::measure::MessageRecvBehaviour;
+    use rings_core::measure::measure::MessageSendehaviour;
+    use rings_core::measure::measure::ConnectBehaviour;
+
+    #impl_token
+    }
+
+    #[cfg(feature = "core_crate")]
+    quote! {
+    use crate::measure::measure::MessageRecvBehaviour;
+    use crate::measure::measure::MessageSendBehaviour;
+    use crate::measure::measure::ConnectBehaviour;
+
+    #impl_token
+    }
+}
+
+pub fn impl_judge_connection_traits(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
+    let name = &ast.ident;
+    #[cfg(feature = "core_crate")]
+    quote! {
+    use crate::transports::manager::JudgeConnection;
+
+    #[cfg_attr(feature = "node", async_trait)]
+    #[cfg_attr(feature = "browser", async_trait(?Send))]
+    impl JudgeConnection for #name {}
+    }
+    #[cfg(not(feature = "core_crate"))]
+    quote! {
+    use rings_core::transports::manager::JudgeConnection;
+
+    #[cfg_attr(feature = "node", async_trait)]
+    #[cfg_attr(feature = "browser", async_trait(?Send))]
+    impl JudgeConnection for #name {}
+    }
+}

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,4 +1,11 @@
 extern crate proc_macro;
+#[macro_use]
+extern crate quote;
+use syn::parse_macro_input;
+use syn::DeriveInput;
+
+mod derives;
+
 use proc_macro::TokenStream;
 #[cfg(feature = "wasm")]
 use quote::quote;
@@ -20,4 +27,16 @@ pub fn wasm_export(attr: TokenStream, input: TokenStream) -> TokenStream {
 
     #[cfg(not(feature = "wasm"))]
     return input;
+}
+
+#[proc_macro_derive(MeasureBehaviour)]
+pub fn impl_measure_behaviour(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    crate::derives::impl_measure_behaviour_traits(&ast).into()
+}
+
+#[proc_macro_derive(JudgeConnection)]
+pub fn impl_judege_connection(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    crate::derives::impl_judge_connection_traits(&ast).into()
 }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -3,12 +3,8 @@ extern crate proc_macro;
 extern crate quote;
 use syn::parse_macro_input;
 use syn::DeriveInput;
-
 mod derives;
-
 use proc_macro::TokenStream;
-#[cfg(feature = "wasm")]
-use quote::quote;
 
 /// If the feature is not "wasm", the macro does nothing; otherwise, it calls wasm_bindgen.
 /// wasm_export does not work for Js Class. To export a class to js,

--- a/node/src/consts.rs
+++ b/node/src/consts.rs
@@ -3,3 +3,9 @@ use crate::prelude::rings_core::consts::*;
 pub const BACKEND_MTU: usize = TRANSPORT_MAX_SIZE - TRANSPORT_MTU;
 /// Redundant setting of vnode data storage
 pub const DATA_REDUNDANT: u16 = 6;
+/// Connect Behaviour
+pub const CONNECT_FAILED_LIMIT: i16 = 3;
+/// Message Send Behaviour
+pub const MSG_SEND_FAILED_LIMIT: i16 = 10;
+/// Message Received Behaviour
+pub const MSG_RECV_FAILED_LIMIT: i16 = 10;

--- a/node/src/measure.rs
+++ b/node/src/measure.rs
@@ -7,6 +7,7 @@ use async_trait::async_trait;
 use chrono::DateTime;
 use chrono::Duration;
 use chrono::Utc;
+use rings_derive::MeasureBehaviour;
 
 use crate::prelude::rings_core::dht::Did;
 use crate::prelude::rings_core::measure;
@@ -25,7 +26,7 @@ const DURATION: u64 = 60 * 60;
 /// `PeriodicMeasure` is used to assess the reliability of peers by counting their behaviour.
 /// It currently count the number of sent and received messages in a given period (1 hour).
 /// The method [Measure::incr] should be called in the proper places.
-#[derive(Debug)]
+#[derive(Debug, MeasureBehaviour)]
 pub struct PeriodicMeasure {
     storage: Arc<PersistenceStorage>,
     counters: DashMap<(Did, MeasureCounter), Mutex<PeriodicCounter>>,
@@ -164,18 +165,6 @@ impl Measure for PeriodicMeasure {
         count
     }
 }
-
-#[cfg_attr(feature = "node", async_trait)]
-#[cfg_attr(feature = "browser", async_trait(?Send))]
-impl<const T: i16> measure::ConnectBehaviour<T> for PeriodicMeasure {}
-
-#[cfg_attr(feature = "node", async_trait)]
-#[cfg_attr(feature = "browser", async_trait(?Send))]
-impl<const T: i16> measure::MessageSendBehaviour<T> for PeriodicMeasure {}
-
-#[cfg_attr(feature = "node", async_trait)]
-#[cfg_attr(feature = "browser", async_trait(?Send))]
-impl<const T: i16> measure::MessageRecvBehaviour<T> for PeriodicMeasure {}
 
 #[cfg_attr(feature = "node", async_trait)]
 #[cfg_attr(feature = "browser", async_trait(?Send))]

--- a/node/src/measure.rs
+++ b/node/src/measure.rs
@@ -49,6 +49,7 @@ impl PeriodicCounter {
         }
     }
 
+    // Reset periodic count on next period
     fn refresh(&mut self) -> bool {
         let now = Utc::now();
 
@@ -62,6 +63,7 @@ impl PeriodicCounter {
         true
     }
 
+    // If there is no recourd in current period, get pervious_count instead
     fn barely_get(&self) -> u64 {
         if self.previous_count == 0 {
             self.count
@@ -70,12 +72,14 @@ impl PeriodicCounter {
         }
     }
 
+    // Check period, then increase
     fn incr(&mut self) -> (u64, bool) {
         let is_refreshed = self.refresh();
         self.count += 1;
         (self.barely_get(), is_refreshed)
     }
 
+    // Check period, return count or pervious count
     fn get(&mut self) -> (u64, bool) {
         let is_refreshed = self.refresh();
         (self.barely_get(), is_refreshed)
@@ -95,6 +99,7 @@ impl PeriodicMeasure {
         format!("PeriodicMeasure/counters/{}/{:?}", did, counter)
     }
 
+    // Get count from storage, or create a new count instance.
     async fn ensure_counter(
         &self,
         did: Did,
@@ -142,7 +147,7 @@ impl Measure for PeriodicMeasure {
         }
     }
 
-    /// `get_count` returns the counter of a peer in the previous period.
+    /// `get_count` returns the counter of a peer in the current or previous period.
     async fn get_count(&self, did: Did, counter: MeasureCounter) -> u64 {
         let (count, is_refreshed) = {
             let c = self.ensure_counter(did, counter).await;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes/features)
- [X] Docs have been added / updated (for bug fixes / features)

## :large_blue_circle: What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
feature

## :brown_circle: What is the current behavior? (You can also link to an open issue here)

related issue https://github.com/RingsNetwork/rings-node/issues/399

In the current scenario, the DHT may attempt to establish a connection to did_a, but this can fail due to incorrect configuration or network issues. The existing implementation might repeatedly try to establish the connection, potentially causing the system's file descriptor limit to be reached very quickly.

## :green_circle: What is the new behavior (if this is a feature change)?

1. A judgement for node behaviour, make sure node is behaviour `good`.
2. A measurement of node behavior, ensuring that the difference between disconnect and connect counts exceeds the THRESHOLD.
3. Throw a new error type: NodeBehaviourBad.
4. Record behaviour on function `connect`, `connect_via` and `disconnect`.

## :radioactive: Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

## :information_source: Other information

After this modify, if a node is behaviour no good, it will printout errors.

<img width="873" alt="Screenshot 2023-07-26 at 6 51 21 PM" src="https://github.com/RingsNetwork/rings-node/assets/662346/01708fff-ac1e-4e75-9afb-6c811042a64e">


Closes #issue
