### PR TITLE
feat!: one stop constructure function for browser::client

### DIFF
--- a/node/src/browser/client.rs
+++ b/node/src/browser/client.rs
@@ -136,39 +136,59 @@ impl Client {
         let config: ProcessorConfig = serde_yaml::from_str(&config)?;
         Self::new_client_with_storage_internal(config, callback, storage_name).await
     }
+
+    pub async fn new(
+        ice_servers: String,
+        stabilize_timeout: usize,
+        account: String,
+        account_type: String,
+        // Signer should be `async function (proof: string): Promise<Unit8Array>`
+        signer: js_sys::Function,
+        callback: Option<MessageCallbackInstance>,
+    ) -> Result<JsValue, JsValue> {
+        let mut sk_builder = SessionSkBuilder::new(account, account_type);
+        let proof = sk_builder.unsigned_proof();
+        let sig: js_sys::Uint8Array = Uint8Array::from(
+            JsFuture::from(js_sys::Promise::from(
+                signer.call1(&JsValue::NULL, &JsValue::from_str(&proof))?,
+            ))
+            .await?,
+        );
+        sk_builder = sk_builder.set_session_sig(sig.to_vec());
+        let session_sk = sk_builder.build().unwrap();
+        let config = ProcessorConfig::new(ice_servers, session_sk, stabilize_timeout);
+        Ok(JsValue::from(
+            Self::new_client_with_storage_internal(config, callback, "rings-node".to_string())
+                .await?,
+        ))
+    }
 }
 
 #[wasm_export]
 impl Client {
     #[wasm_bindgen(constructor)]
-    pub fn new(
+    pub fn new_instance(
         ice_servers: String,
         stabilize_timeout: usize,
         account: String,
         account_type: String,
-	// Signer should be `async function (proof: string): Promise<Unit8Array>`
+        // Signer should be `async function (proof: string): Promise<Unit8Array>`
         signer: js_sys::Function,
         callback: Option<MessageCallbackInstance>,
-    //) -> Result<Client, error::Error> {
+        //) -> Result<Client, error::Error> {
     ) -> js_sys::Promise {
-	future_to_promise(async move {
-            let mut sk_builder = SessionSkBuilder::new(account, account_type);
-            let proof = sk_builder.unsigned_proof();
-            let sig: js_sys::Uint8Array = Uint8Array::from(
-		JsFuture::from(
-		    js_sys::Promise::from(
-			signer
-			    .call1(&JsValue::NULL, &JsValue::from_str(&proof))?
-		    )
-		).await?
-            );
-            sk_builder = sk_builder.set_session_sig(sig.to_vec());
-            let session_sk = sk_builder.build().unwrap();
-            let config = ProcessorConfig::new(ice_servers, session_sk, stabilize_timeout);
-            Ok(JsValue::from(Self::new_client_with_storage_internal(config, callback, "rings-node".to_string()).await?))
-	})
+        future_to_promise(async move {
+            Self::new(
+                ice_servers,
+                stabilize_timeout,
+                account,
+                account_type,
+                signer,
+                callback,
+            )
+            .await
+        })
     }
-
     /// Create new client instance with serialized config (yaml/json)
     pub fn new_client_with_serialized_config(
         config: String,
@@ -176,16 +196,6 @@ impl Client {
     ) -> js_sys::Promise {
         let cfg: ProcessorConfig = serde_yaml::from_str(&config).unwrap();
         Self::new_client_with_config(cfg, callback)
-    }
-
-    /// Create new client instance with storage name and serialized config (yaml/json)
-    pub fn new_client_with_storage_and_serialized_config(
-        config: String,
-        callback: Option<MessageCallbackInstance>,
-        storage_name: String,
-    ) -> js_sys::Promise {
-        let cfg: ProcessorConfig = serde_yaml::from_str(&config).unwrap();
-        Self::new_client_with_storage(cfg, callback, storage_name)
     }
 
     /// Create a new client instance.

--- a/node/src/browser/client.rs
+++ b/node/src/browser/client.rs
@@ -163,11 +163,10 @@ impl Client {
             sk_builder = sk_builder.set_session_sig(sig.to_vec());
             let session_sk = sk_builder.build().unwrap();
             let config = ProcessorConfig::new(ice_servers, session_sk, stabilize_timeout);
-            Ok(
-                JsValue::from(
-		    Self::new_client_with_storage_internal(config, callback, "rings-node".to_string())
-			.await?)
-            )
+            Ok(JsValue::from(
+                Self::new_client_with_storage_internal(config, callback, "rings-node".to_string())
+                    .await?,
+            ))
         })
     }
 

--- a/node/src/browser/client.rs
+++ b/node/src/browser/client.rs
@@ -141,7 +141,7 @@ impl Client {
 #[wasm_export]
 impl Client {
     #[wasm_bindgen(constructor)]
-    pub fn new(
+    pub fn new_instance(
         ice_servers: String,
         stabilize_timeout: usize,
         account: String,

--- a/node/src/error.rs
+++ b/node/src/error.rs
@@ -99,7 +99,9 @@ pub enum Error {
     #[error("verify error: {0}")]
     VerifyError(String) = 1002,
     #[error("core error: {0}")]
-    CoreError(String) = 1102,
+    CoreError(#[from] rings_core::error::Error) = 1102,
+    #[error("external singer error: {0}")]
+    ExternalError(String) = 1202,
 }
 
 impl Error {

--- a/node/src/processor.rs
+++ b/node/src/processor.rs
@@ -157,10 +157,7 @@ impl TryFrom<ProcessorConfig> for ProcessorConfigSerialized {
         Ok(Self {
             ice_servers: ins.ice_servers.clone(),
             external_address: ins.external_address.clone(),
-            session_sk: ins
-                .session_sk
-                .dump()
-                .map_err(|e| Error::CoreError(e.to_string()))?,
+            session_sk: ins.session_sk.dump()?,
             stabilize_timeout: ins.stabilize_timeout,
         })
     }
@@ -172,8 +169,7 @@ impl TryFrom<ProcessorConfigSerialized> for ProcessorConfig {
         Ok(Self {
             ice_servers: ins.ice_servers.clone(),
             external_address: ins.external_address.clone(),
-            session_sk: SessionSk::from_str(&ins.session_sk)
-                .map_err(|e| Error::CoreError(e.to_string()))?,
+            session_sk: SessionSk::from_str(&ins.session_sk)?,
             stabilize_timeout: ins.stabilize_timeout,
         })
     }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

## :large_blue_circle: What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

feature

## :brown_circle: What is the current behavior? (You can also link to an open issue here)

Three or four steps is needed for creating a client instance, and it's hard to understand for users.

## :green_circle: What is the new behavior (if this is a feature change)?

Make browser::client can be contracture with one stop function.

```rust
    #[wasm_bindgen(constructor)]
    pub fn new_instance(
        ice_servers: String,
        stabilize_timeout: usize,
        account: String,
        account_type: String,
        // Signer should be `async function (proof: string): Promise<Unit8Array>`
        signer: js_sys::Function,
        callback: Option<MessageCallbackInstance>,
        //) -> Result<Client, error::Error> {
    ) -> js_sys::Promise 
```

The impl can be used with (this example if from rings_ext_v2):

```typescript
    let signer = async (proof: string): Promise<Uint8Array> => {
      const { signed } = await sendMessage(
        'sign-message',
        {
          auth: proof,
        },
        'popup'
      )
      return new Uint8Array(hexToBytes(signed));
    }
    let callback = gen_callback()
    let client_: Client = await new Client(
      // ice_servers
      turnUrl,
      // stable_tineout
      100,
      // account
      account,
      // account type
      "eip191",
      // signer
      signer,
      // callback
      callback
    )
```

## :radioactive: Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Yes, some help functions are removed

## :information_source: Other information

Closes #issue
