### PR TITLE
chore: remove web3 dependency and fix Did display prefix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,26 +504,14 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitvec"
-version = "0.20.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
-dependencies = [
- "funty 1.1.0",
- "radium 0.6.2",
- "tap",
- "wyz 0.2.0",
-]
-
-[[package]]
-name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
- "funty 2.0.0",
- "radium 0.7.0",
+ "funty",
+ "radium",
  "tap",
- "wyz 0.5.1",
+ "wyz",
 ]
 
 [[package]]
@@ -532,7 +520,6 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding",
  "generic-array",
 ]
 
@@ -753,12 +740,6 @@ name = "const-oid"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-foundation-sys"
@@ -1202,19 +1183,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_more"
-version = "0.99.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1401,25 +1369,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ethabi"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c98847055d934070b90e806e12d3936b787d0a115068981c1d8dfd5dfef5a5"
-dependencies = [
- "ethereum-types",
- "hex",
- "serde",
- "serde_json",
- "sha3",
- "thiserror",
- "uint",
-]
-
-[[package]]
 name = "ethbloom"
-version = "0.11.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb684ac8fa8f6c5759f788862bb22ec6fe3cb392f6bfd08e3c64b603661e3f8"
+checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
 dependencies = [
  "crunchy",
  "fixed-hash",
@@ -1430,9 +1383,9 @@ dependencies = [
 
 [[package]]
 name = "ethereum-types"
-version = "0.12.1"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05136f7057fe789f06e6d41d07b34e6f70d8c86e5693b60f97aaa6553553bdaf"
+checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
 dependencies = [
  "ethbloom",
  "fixed-hash",
@@ -1472,9 +1425,9 @@ checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
 
 [[package]]
 name = "fixed-hash"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
  "rand 0.8.5",
@@ -1531,12 +1484,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "funty"
@@ -1621,10 +1568,6 @@ name = "futures-timer"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
-dependencies = [
- "gloo-timers",
- "send_wrapper",
-]
 
 [[package]]
 name = "futures-util"
@@ -1723,18 +1666,6 @@ name = "gimli"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
-
-[[package]]
-name = "gloo-timers"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "group"
@@ -2003,17 +1934,6 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
-name = "idna"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
@@ -2024,9 +1944,9 @@ dependencies = [
 
 [[package]]
 name = "impl-codec"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161ebdfec3c8e3b52bf61c4f3550a1eea4f9579d10dc1b936f3171ebdcd6c443"
+checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2042,9 +1962,9 @@ dependencies = [
 
 [[package]]
 name = "impl-serde"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
+checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
 dependencies = [
  "serde",
 ]
@@ -2219,15 +2139,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "keccak"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
-dependencies = [
- "cpufeatures",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2329,12 +2240,6 @@ checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "matches"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "matchit"
@@ -2665,12 +2570,12 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "2.3.1"
+version = "3.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373b1a4c1338d9cd3d1fa53b3a11bdab5ab6bd80a20f7f7becd76953ae2be909"
+checksum = "dd8e946cc0cc711189c0b0249fb8b599cbeeab9784d83c415719368bb8d4ac64"
 dependencies = [
  "arrayvec",
- "bitvec 0.20.4",
+ "bitvec",
  "byte-slice-cast",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
@@ -2679,9 +2584,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "2.3.1"
+version = "3.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
+checksum = "2a296c3079b5fefbc499e1de58dc26c09b1b9a5952d26694ee89f04a43ebbb3e"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2841,9 +2746,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "primitive-types"
-version = "0.10.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
+checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
 dependencies = [
  "fixed-hash",
  "impl-codec",
@@ -2923,12 +2828,6 @@ checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "radium"
@@ -3272,6 +3171,7 @@ dependencies = [
  "ecies",
  "ed25519",
  "ed25519-dalek",
+ "ethereum-types",
  "flate2",
  "futures",
  "futures-timer",
@@ -3294,6 +3194,7 @@ dependencies = [
  "sha2 0.10.6",
  "sled",
  "thiserror",
+ "tiny-keccak",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3304,7 +3205,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
- "web3",
  "webrtc 0.6.0",
 ]
 
@@ -3426,7 +3326,7 @@ version = "0.7.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0200c8230b013893c0b2d6213d6ec64ed2b9be2e0e016682b7224ff82cff5c58"
 dependencies = [
- "bitvec 1.0.1",
+ "bitvec",
  "bytecheck",
  "hashbrown 0.12.3",
  "indexmap",
@@ -3519,15 +3419,6 @@ name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
 
 [[package]]
 name = "rusticata-macros"
@@ -3685,18 +3576,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
-
-[[package]]
-name = "send_wrapper"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
-
-[[package]]
 name = "serde"
 version = "1.0.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3829,18 +3708,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.7",
-]
-
-[[package]]
-name = "sha3"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "keccak",
- "opaque-debug",
 ]
 
 [[package]]
@@ -4535,7 +4402,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
- "idna 0.4.0",
+ "idna",
  "percent-encoding",
  "serde",
 ]
@@ -4910,40 +4777,6 @@ checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "web3"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f258e254752d210b84fe117b31f1e3cc9cbf04c0d747eb7f8cf7cf5e370f6d"
-dependencies = [
- "arrayvec",
- "base64 0.13.1",
- "bytes",
- "derive_more",
- "ethabi",
- "ethereum-types",
- "futures",
- "futures-timer",
- "getrandom 0.2.9",
- "headers",
- "hex",
- "idna 0.2.3",
- "js-sys",
- "jsonrpc-core",
- "log",
- "parking_lot 0.12.1",
- "pin-project",
- "rand 0.8.5",
- "reqwest",
- "rlp",
- "serde",
- "serde_json",
- "tiny-keccak",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -5451,12 +5284,6 @@ checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]
-
-[[package]]
-name = "wyz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "wyz"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,7 +20,6 @@ std = [
     "webrtc",
     "async-channel",
     "sled",
-    "web3/http-rustls-tls",
     "futures/default",
     "uuid/v4",
     "uuid/serde",
@@ -35,7 +34,6 @@ wasm = [
     "wasm-bindgen-futures",
     "rexie",
     "serde-wasm-bindgen",
-    "web3/wasm",
     "futures",
     "uuid/wasm-bindgen",
     "uuid/v4",
@@ -62,6 +60,7 @@ derivative = "2.2.0"
 ecies = { version = "0.2", default-features = false, features = ["pure"] }
 ed25519 = "1.5.2"
 ed25519-dalek = "1.0.1"
+ethereum-types = { version = "0.14.1" }
 flate2 = { version = "1.0.22" }
 futures-timer = "3.0.2"
 hex = "0.4.3"
@@ -82,8 +81,8 @@ url = { version = "2", features = ["serde"] }
 
 futures = { version = "0.3.21", default-features = false, optional = true }
 rings-derive = { workspace = true, optional = true, features = ["core_crate"] }
+tiny-keccak = { version = "2.0.1", features = ["keccak"] }
 uuid = { version = "0.8.2", optional = true }
-web3 = { version = "0.18.0", default-features = false, optional = true }
 
 # default and dummy
 async-channel = { version = "1.6.1", optional = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,7 +20,6 @@ std = [
     "webrtc",
     "async-channel",
     "sled",
-    "futures/default",
     "uuid/v4",
     "uuid/serde",
     "rings-derive/default",
@@ -34,7 +33,6 @@ wasm = [
     "wasm-bindgen-futures",
     "rexie",
     "serde-wasm-bindgen",
-    "futures",
     "uuid/wasm-bindgen",
     "uuid/v4",
     "uuid/serde",
@@ -60,8 +58,9 @@ derivative = "2.2.0"
 ecies = { version = "0.2", default-features = false, features = ["pure"] }
 ed25519 = "1.5.2"
 ed25519-dalek = "1.0.1"
-ethereum-types = { version = "0.14.1" }
-flate2 = { version = "1.0.22" }
+ethereum-types = "0.14.1"
+flate2 = "1.0.22"
+futures = "0.3.21"
 futures-timer = "3.0.2"
 hex = "0.4.3"
 itertools = "0.10.3"
@@ -72,14 +71,13 @@ rand_core = { version = "0.6.3", features = ["getrandom"] }
 rand_hc = "0.3.1"
 rings-transport = { workspace = true }
 serde = { version = "1.0.130", features = ["derive"] }
-serde_json = { version = "1.0.70" }
+serde_json = "1.0.70"
 sha1 = "0.10.1"
 sha2 = "0.10.6"
 thiserror = "1"
 tracing = "0.1.37"
 url = { version = "2", features = ["serde"] }
 
-futures = { version = "0.3.21", default-features = false, optional = true }
 rings-derive = { workspace = true, optional = true, features = ["core_crate"] }
 tiny-keccak = { version = "2.0.1", features = ["keccak"] }
 uuid = { version = "0.8.2", optional = true }

--- a/core/src/dht/did.rs
+++ b/core/src/dht/did.rs
@@ -56,7 +56,7 @@ pub struct Did(H160);
 impl std::fmt::Display for Did {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let inner = &self.0;
-        write!(f, "{inner:x}")
+        write!(f, "0x{inner:x}")
     }
 }
 
@@ -355,8 +355,10 @@ mod tests {
 
         // from_str then to_string
         let did = Did::from_str("0x11E807fcc88dD319270493fB2e822e388Fe36ab0").unwrap();
-        // TODO: Should be "0x11e807fcc88dd319270493fb2e822e388fe36ab0"
-        assert_eq!(did.to_string(), "11e807fcc88dd319270493fb2e822e388fe36ab0");
+        assert_eq!(
+            did.to_string(),
+            "0x11e807fcc88dd319270493fb2e822e388fe36ab0"
+        );
 
         // Serialize
         let did = Did::from_str("0x11E807fcc88dD319270493fB2e822e388Fe36ab0").unwrap();
@@ -375,10 +377,9 @@ mod tests {
 
         // Debug and Display
         let did = Did::from_str("0x11E807fcc88dD319270493fB2e822e388Fe36ab0").unwrap();
-        // TODO: Should be "0x11e807fcc88dd319270493fb2e822e388fe36ab0"
         assert_eq!(
             format!("{}", did),
-            "11e807fcc88dd319270493fb2e822e388fe36ab0"
+            "0x11e807fcc88dd319270493fb2e822e388fe36ab0"
         );
         assert_eq!(
             format!("{:?}", did),

--- a/core/src/dht/did.rs
+++ b/core/src/dht/did.rs
@@ -40,11 +40,10 @@ use std::ops::Neg;
 use std::ops::Sub;
 use std::str::FromStr;
 
+use ethereum_types::H160;
 use num_bigint::BigUint;
 use serde::Deserialize;
 use serde::Serialize;
-use web3::contract::tokens::Tokenizable;
-use web3::types::H160;
 
 use crate::ecc::HashStr;
 use crate::error::Error;
@@ -56,7 +55,8 @@ pub struct Did(H160);
 
 impl std::fmt::Display for Did {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", self.into_token())
+        let inner = &self.0;
+        write!(f, "{inner:x}")
     }
 }
 

--- a/core/src/ecc/mod.rs
+++ b/core/src/ecc/mod.rs
@@ -4,6 +4,7 @@ use std::fmt::Write;
 use std::ops::Deref;
 use std::str::FromStr;
 
+use ethereum_types::H160;
 use hex;
 use rand::SeedableRng;
 use rand_hc::Hc128Rng;
@@ -11,8 +12,6 @@ use serde::Deserialize;
 use serde::Serialize;
 use sha1::Digest;
 use sha1::Sha1;
-use web3::signing::keccak256;
-use web3::types::Address;
 
 use crate::error::Error;
 use crate::error::Result;
@@ -35,6 +34,17 @@ pub struct SecretKey(libsecp256k1::SecretKey);
 /// Wrap String into HashStr.
 #[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]
 pub struct HashStr(String);
+
+/// Compute the Keccak-256 hash of input bytes.
+pub fn keccak256(bytes: &[u8]) -> [u8; 32] {
+    use tiny_keccak::Hasher;
+    use tiny_keccak::Keccak;
+    let mut output = [0u8; 32];
+    let mut hasher = Keccak::v256();
+    hasher.update(bytes);
+    hasher.finalize(&mut output);
+    output
+}
 
 impl HashStr {
     pub fn new<T: Into<String>>(s: T) -> Self {
@@ -196,7 +206,7 @@ impl Serialize for SecretKey {
     }
 }
 
-fn public_key_address(pubkey: &PublicKey) -> Address {
+fn public_key_address(pubkey: &PublicKey) -> H160 {
     let hash = match TryInto::<libsecp256k1::PublicKey>::try_into(*pubkey) {
         // if pubkey is ecdsa key
         Ok(pk) => {
@@ -207,10 +217,10 @@ fn public_key_address(pubkey: &PublicKey) -> Address {
         // if pubkey is eddsa key
         Err(_) => keccak256(&pubkey.0[1..]),
     };
-    Address::from_slice(&hash[12..])
+    H160::from_slice(&hash[12..])
 }
 
-fn secret_key_address(secret_key: &SecretKey) -> Address {
+fn secret_key_address(secret_key: &SecretKey) -> H160 {
     let public_key = libsecp256k1::PublicKey::from_secret_key(secret_key);
     public_key_address(&public_key.into())
 }
@@ -221,7 +231,7 @@ impl SecretKey {
         Self(libsecp256k1::SecretKey::random(&mut rng))
     }
 
-    pub fn address(&self) -> Address {
+    pub fn address(&self) -> H160 {
         secret_key_address(self)
     }
 
@@ -254,7 +264,7 @@ impl SecretKey {
 }
 
 impl PublicKey {
-    pub fn address(&self) -> Address {
+    pub fn address(&self) -> H160 {
         public_key_address(self)
     }
 }

--- a/core/src/ecc/mod.rs
+++ b/core/src/ecc/mod.rs
@@ -26,6 +26,8 @@ pub use types::PublicKey;
 pub type SigBytes = [u8; 65];
 /// Alias PublicKey.
 pub type CurveEle = PublicKey;
+/// PublicKeyAddress is H160.
+pub type PublicKeyAddress = H160;
 
 /// Wrap libsecp256k1::SecretKey.
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
@@ -206,7 +208,7 @@ impl Serialize for SecretKey {
     }
 }
 
-fn public_key_address(pubkey: &PublicKey) -> H160 {
+fn public_key_address(pubkey: &PublicKey) -> PublicKeyAddress {
     let hash = match TryInto::<libsecp256k1::PublicKey>::try_into(*pubkey) {
         // if pubkey is ecdsa key
         Ok(pk) => {
@@ -217,10 +219,10 @@ fn public_key_address(pubkey: &PublicKey) -> H160 {
         // if pubkey is eddsa key
         Err(_) => keccak256(&pubkey.0[1..]),
     };
-    H160::from_slice(&hash[12..])
+    PublicKeyAddress::from_slice(&hash[12..])
 }
 
-fn secret_key_address(secret_key: &SecretKey) -> H160 {
+fn secret_key_address(secret_key: &SecretKey) -> PublicKeyAddress {
     let public_key = libsecp256k1::PublicKey::from_secret_key(secret_key);
     public_key_address(&public_key.into())
 }
@@ -231,7 +233,7 @@ impl SecretKey {
         Self(libsecp256k1::SecretKey::random(&mut rng))
     }
 
-    pub fn address(&self) -> H160 {
+    pub fn address(&self) -> PublicKeyAddress {
         secret_key_address(self)
     }
 
@@ -264,7 +266,7 @@ impl SecretKey {
 }
 
 impl PublicKey {
-    pub fn address(&self) -> H160 {
+    pub fn address(&self) -> PublicKeyAddress {
         public_key_address(self)
     }
 }

--- a/core/src/ecc/signers/bip137.rs
+++ b/core/src/ecc/signers/bip137.rs
@@ -4,8 +4,8 @@ use arrayref::array_mut_ref;
 use sha2::Digest;
 use sha2::Sha256;
 
-use crate::ecc::Address;
 use crate::ecc::PublicKey;
+use crate::ecc::H160;
 use crate::error::Result;
 
 /// recover pubkey according to signature.
@@ -20,7 +20,7 @@ pub fn recover(msg: &str, sig: impl AsRef<[u8]>) -> Result<PublicKey> {
 }
 
 /// verify message signed by Ethereum address.
-pub fn verify(msg: &str, address: &Address, sig: impl AsRef<[u8]>) -> bool {
+pub fn verify(msg: &str, address: &H160, sig: impl AsRef<[u8]>) -> bool {
     match recover(msg, sig.as_ref()) {
         Ok(recover_pk) => {
             if recover_pk.address() == *address {

--- a/core/src/ecc/signers/bip137.rs
+++ b/core/src/ecc/signers/bip137.rs
@@ -5,7 +5,7 @@ use sha2::Digest;
 use sha2::Sha256;
 
 use crate::ecc::PublicKey;
-use crate::ecc::H160;
+use crate::ecc::PublicKeyAddress;
 use crate::error::Result;
 
 /// recover pubkey according to signature.
@@ -20,7 +20,7 @@ pub fn recover(msg: &str, sig: impl AsRef<[u8]>) -> Result<PublicKey> {
 }
 
 /// verify message signed by Ethereum address.
-pub fn verify(msg: &str, address: &H160, sig: impl AsRef<[u8]>) -> bool {
+pub fn verify(msg: &str, address: &PublicKeyAddress, sig: impl AsRef<[u8]>) -> bool {
     match recover(msg, sig.as_ref()) {
         Ok(recover_pk) => {
             if recover_pk.address() == *address {

--- a/core/src/ecc/signers/ed25519.rs
+++ b/core/src/ecc/signers/ed25519.rs
@@ -2,10 +2,15 @@
 use ed25519_dalek::Verifier;
 
 use crate::ecc::PublicKey;
-use crate::ecc::H160;
+use crate::ecc::PublicKeyAddress;
 
 /// ref <https://www.rfc-editor.org/rfc/rfc8709>
-pub fn verify(msg: &str, address: &H160, sig: impl AsRef<[u8]>, pubkey: PublicKey) -> bool {
+pub fn verify(
+    msg: &str,
+    address: &PublicKeyAddress,
+    sig: impl AsRef<[u8]>,
+    pubkey: PublicKey,
+) -> bool {
     if pubkey.address() != *address {
         return false;
     }

--- a/core/src/ecc/signers/ed25519.rs
+++ b/core/src/ecc/signers/ed25519.rs
@@ -1,11 +1,11 @@
 //! ed25519 sign algorithm using ed25519_dalek
 use ed25519_dalek::Verifier;
 
-use crate::ecc::Address;
 use crate::ecc::PublicKey;
+use crate::ecc::H160;
 
 /// ref <https://www.rfc-editor.org/rfc/rfc8709>
-pub fn verify(msg: &str, address: &Address, sig: impl AsRef<[u8]>, pubkey: PublicKey) -> bool {
+pub fn verify(msg: &str, address: &H160, sig: impl AsRef<[u8]>, pubkey: PublicKey) -> bool {
     if pubkey.address() != *address {
         return false;
     }

--- a/core/src/ecc/signers/eip191.rs
+++ b/core/src/ecc/signers/eip191.rs
@@ -3,8 +3,8 @@
 
 use crate::ecc::keccak256;
 use crate::ecc::PublicKey;
+use crate::ecc::PublicKeyAddress;
 use crate::ecc::SecretKey;
-use crate::ecc::H160;
 use crate::error::Result;
 
 /// sign function passing raw message parameter.
@@ -36,7 +36,7 @@ pub fn recover(msg: &str, sig: impl AsRef<[u8]>) -> Result<PublicKey> {
 }
 
 /// verify message signed by Ethereum address.
-pub fn verify(msg: &str, address: &H160, sig: impl AsRef<[u8]>) -> bool {
+pub fn verify(msg: &str, address: &PublicKeyAddress, sig: impl AsRef<[u8]>) -> bool {
     if let Ok(p) = recover(msg, sig) {
         p.address() == *address
     } else {
@@ -57,7 +57,8 @@ mod test {
         let key =
             SecretKey::try_from("65860affb4b570dba06db294aa7c676f68e04a5bf2721243ad3cbc05a79c68c0")
                 .unwrap();
-        let address = H160::from_str("0x11E807fcc88dD319270493fB2e822e388Fe36ab0").unwrap();
+        let address =
+            PublicKeyAddress::from_str("0x11E807fcc88dD319270493fB2e822e388Fe36ab0").unwrap();
 
         // window.ethereum.request({method: "personal_sign", params: ["test", "0x11E807fcc88dD319270493fB2e822e388Fe36ab0"]})
         let metamask_sig = Vec::from_hex("724fc31d9272b34d8406e2e3a12a182e72510b008de6cc44684577e31e20d9626fb760d6a0badd79a6cf4cd56b2fc0fbd60c438b809aa7d29bfb598c13e7b50e1b").unwrap();

--- a/core/src/ecc/signers/eip191.rs
+++ b/core/src/ecc/signers/eip191.rs
@@ -1,11 +1,10 @@
 //! eip191.
 //! ref <https://eips.ethereum.org/EIPS/eip-191>
 
-use web3::signing::keccak256;
-
-use crate::ecc::Address;
+use crate::ecc::keccak256;
 use crate::ecc::PublicKey;
 use crate::ecc::SecretKey;
+use crate::ecc::H160;
 use crate::error::Result;
 
 /// sign function passing raw message parameter.
@@ -37,7 +36,7 @@ pub fn recover(msg: &str, sig: impl AsRef<[u8]>) -> Result<PublicKey> {
 }
 
 /// verify message signed by Ethereum address.
-pub fn verify(msg: &str, address: &Address, sig: impl AsRef<[u8]>) -> bool {
+pub fn verify(msg: &str, address: &H160, sig: impl AsRef<[u8]>) -> bool {
     if let Ok(p) = recover(msg, sig) {
         p.address() == *address
     } else {
@@ -50,7 +49,6 @@ mod test {
     use std::str::FromStr;
 
     use super::*;
-    use crate::ecc::Address;
     use crate::ecc::SecretKey;
 
     #[test]
@@ -59,7 +57,7 @@ mod test {
         let key =
             SecretKey::try_from("65860affb4b570dba06db294aa7c676f68e04a5bf2721243ad3cbc05a79c68c0")
                 .unwrap();
-        let address = Address::from_str("0x11E807fcc88dD319270493fB2e822e388Fe36ab0").unwrap();
+        let address = H160::from_str("0x11E807fcc88dD319270493fB2e822e388Fe36ab0").unwrap();
 
         // window.ethereum.request({method: "personal_sign", params: ["test", "0x11E807fcc88dD319270493fB2e822e388Fe36ab0"]})
         let metamask_sig = Vec::from_hex("724fc31d9272b34d8406e2e3a12a182e72510b008de6cc44684577e31e20d9626fb760d6a0badd79a6cf4cd56b2fc0fbd60c438b809aa7d29bfb598c13e7b50e1b").unwrap();

--- a/core/src/ecc/signers/secp256k1.rs
+++ b/core/src/ecc/signers/secp256k1.rs
@@ -2,8 +2,8 @@
 
 use crate::ecc::keccak256;
 use crate::ecc::PublicKey;
+use crate::ecc::PublicKeyAddress;
 use crate::ecc::SecretKey;
-use crate::ecc::H160;
 use crate::error::Result;
 
 /// sign function passing raw message parameter.
@@ -28,7 +28,7 @@ pub fn recover(msg: &str, sig: impl AsRef<[u8]>) -> Result<PublicKey> {
 }
 
 /// verify signature with message and address.
-pub fn verify(msg: &str, address: &H160, sig: impl AsRef<[u8]>) -> bool {
+pub fn verify(msg: &str, address: &PublicKeyAddress, sig: impl AsRef<[u8]>) -> bool {
     if let Ok(p) = recover(msg, sig) {
         p.address() == *address
     } else {

--- a/core/src/ecc/signers/secp256k1.rs
+++ b/core/src/ecc/signers/secp256k1.rs
@@ -1,9 +1,9 @@
 //! Default method signing using libsecp256k1::SecretKey.
-use web3::signing::keccak256;
 
-use crate::ecc::Address;
+use crate::ecc::keccak256;
 use crate::ecc::PublicKey;
 use crate::ecc::SecretKey;
+use crate::ecc::H160;
 use crate::error::Result;
 
 /// sign function passing raw message parameter.
@@ -28,7 +28,7 @@ pub fn recover(msg: &str, sig: impl AsRef<[u8]>) -> Result<PublicKey> {
 }
 
 /// verify signature with message and address.
-pub fn verify(msg: &str, address: &Address, sig: impl AsRef<[u8]>) -> bool {
+pub fn verify(msg: &str, address: &H160, sig: impl AsRef<[u8]>) -> bool {
     if let Ok(p) = recover(msg, sig) {
         p.address() == *address
     } else {

--- a/core/src/prelude.rs
+++ b/core/src/prelude.rs
@@ -7,8 +7,6 @@ pub use futures;
 pub use libsecp256k1;
 pub use url;
 pub use uuid;
-pub use web3;
-pub use web3::types::Address;
 
 pub use crate::dht::vnode;
 pub use crate::message;

--- a/core/src/storage/memory.rs
+++ b/core/src/storage/memory.rs
@@ -68,15 +68,15 @@ where
 
 #[cfg(test)]
 mod tests {
-    use web3::types::Address;
 
     use super::*;
+    use crate::dht::Did;
     use crate::ecc::SecretKey;
 
     #[test]
     fn memstorage_basic_interface_should_work() {
-        let store = MemStorage::<Address, String>::new();
-        let addr = SecretKey::random().address();
+        let store = MemStorage::<Did, String>::new();
+        let addr = SecretKey::random().address().into();
 
         assert!(store.get(&addr).is_none());
 

--- a/core/src/tests/wasm/test_idb_storage.rs
+++ b/core/src/tests/wasm/test_idb_storage.rs
@@ -41,8 +41,7 @@ async fn test_create_put_data() {
     assert!(store.count(None).await.unwrap() == 1, "indexedDB is empty");
 
     let real_value_1 = store.get(&JsValue::from(&key)).await.unwrap();
-    #[allow(deprecated)]
-    let real_value_1: JsonValue = real_value_1.into_serde().unwrap();
+    let real_value_1: JsonValue = serde_wasm_bindgen::from_value(real_value_1).unwrap();
     let last_visit_1 = real_value_1
         .get("last_visit_time")
         .unwrap()
@@ -69,8 +68,7 @@ async fn test_create_put_data() {
     let (_tx, store) = instance.get_tx_store(TransactionMode::ReadOnly).unwrap();
     assert!(store.count(None).await.unwrap() == 1, "indexedDB is empty");
     let real_value_2 = store.get(&JsValue::from(&key)).await.unwrap();
-    #[allow(deprecated)]
-    let real_value_2: JsonValue = real_value_2.into_serde().unwrap();
+    let real_value_2: JsonValue = serde_wasm_bindgen::from_value(real_value_2).unwrap();
     let last_visit_2 = real_value_2
         .get("last_visit_time")
         .unwrap()
@@ -241,8 +239,8 @@ async fn test_idb_total_size() {
     };
     instance.put(&key1, &value1).await.unwrap();
     #[allow(deprecated)]
-    let expect_size =
-        size_of_val(&JsValue::from(key1)) + size_of_val(&JsValue::from_serde(&value1).unwrap());
+    let expect_size = size_of_val(&JsValue::from(key1))
+        + size_of_val(&serde_wasm_bindgen::to_value(&value1).unwrap());
     let total_size = instance.total_size().await.unwrap();
     assert!(total_size > 0, "total_size should > 0");
     assert!(

--- a/node/src/browser/client.rs
+++ b/node/src/browser/client.rs
@@ -19,7 +19,6 @@ use rings_core::message::MessageHandlerEvent;
 use rings_core::message::MessagePayload;
 use rings_core::prelude::vnode;
 use rings_core::prelude::vnode::VirtualNode;
-use rings_core::prelude::web3::ethabi::Token;
 use rings_core::session::SessionSkBuilder;
 use rings_core::storage::PersistenceStorage;
 use rings_core::swarm::impls::ConnectionHandshake;
@@ -52,7 +51,6 @@ use crate::prelude::jsonrpc_core::types::id::Id;
 use crate::prelude::jsonrpc_core::MethodCall;
 use crate::prelude::message;
 use crate::prelude::wasm_export;
-use crate::prelude::web3::contract::tokens::Tokenizable;
 use crate::prelude::CallbackFn;
 use crate::processor::Processor;
 use crate::processor::ProcessorBuilder;
@@ -186,7 +184,7 @@ impl Client {
     /// get self web3 address
     #[wasm_bindgen(getter)]
     pub fn address(&self) -> String {
-        self.processor.did().into_token().to_string()
+        self.processor.did().to_string()
     }
 
     pub fn new_client_with_storage(
@@ -258,7 +256,7 @@ impl Client {
                 .connect_peer_via_http(remote_url.as_str())
                 .await
                 .map_err(JsError::from)?;
-            Ok(JsValue::from_str(peer.did.to_string().as_str()))
+            Ok(JsValue::from_str(peer.did.as_str()))
         })
     }
 
@@ -342,7 +340,7 @@ impl Client {
                 .await
                 .map_err(JsError::from)?;
             let state = conn.webrtc_connection_state();
-            Ok(JsValue::try_from(&Peer::from((state, did.into_token())))?)
+            Ok(JsValue::try_from(&Peer::from((state, did.to_string())))?)
         })
     }
 
@@ -844,10 +842,10 @@ pub struct Peer {
     pub state: String,
 }
 
-impl From<(WebrtcConnectionState, Token)> for Peer {
-    fn from((st, address): (WebrtcConnectionState, Token)) -> Self {
+impl From<(WebrtcConnectionState, String)> for Peer {
+    fn from((st, address): (WebrtcConnectionState, String)) -> Self {
         Self {
-            address: address.to_string(),
+            address,
             state: format!("{:?}", st),
         }
     }
@@ -911,7 +909,6 @@ pub fn get_address_from_hex_pubkey(pubkey: String) -> Result<String, JsError> {
     Ok(PublicKey::from_hex_string(pubkey.as_str())
         .map_err(JsError::from)?
         .address()
-        .into_token()
         .to_string())
 }
 
@@ -920,5 +917,5 @@ pub fn get_address_from_hex_pubkey(pubkey: String) -> Result<String, JsError> {
 ///   * addr_type: source address type
 #[wasm_export]
 pub fn get_address(address: &str, addr_type: AddressType) -> Result<String, JsError> {
-    Ok(get_did(address, addr_type)?.into_token().to_string())
+    Ok(get_did(address, addr_type)?.to_string())
 }

--- a/node/src/browser/client.rs
+++ b/node/src/browser/client.rs
@@ -906,10 +906,12 @@ pub fn get_did(address: &str, addr_type: AddressType) -> Result<Did, JsError> {
 ///  * pubkey: hex pubkey
 #[wasm_export]
 pub fn get_address_from_hex_pubkey(pubkey: String) -> Result<String, JsError> {
-    Ok(PublicKey::from_hex_string(pubkey.as_str())
-        .map_err(JsError::from)?
-        .address()
-        .to_string())
+    Ok(Did::from(
+        PublicKey::from_hex_string(pubkey.as_str())
+            .map_err(JsError::from)?
+            .address(),
+    )
+    .to_string())
 }
 
 /// Get address from other address

--- a/node/src/jsonrpc/server.rs
+++ b/node/src/jsonrpc/server.rs
@@ -122,7 +122,7 @@ pub(crate) async fn connect_peer_via_http(params: Params, meta: RpcMeta) -> Resu
         .connect_peer_via_http(peer_url)
         .await
         .map_err(Error::from)?;
-    Ok(Value::String(peer.did.to_string()))
+    Ok(Value::String(peer.did))
 }
 
 /// Connect Peer with seed

--- a/node/src/prelude.rs
+++ b/node/src/prelude.rs
@@ -27,7 +27,6 @@ pub use self::rings_core::prelude::base58;
 pub use self::rings_core::prelude::message;
 pub use self::rings_core::prelude::uuid;
 pub use self::rings_core::prelude::vnode;
-pub use self::rings_core::prelude::web3;
 pub use self::rings_core::prelude::ChordStorageInterface;
 pub use self::rings_core::prelude::ChordStorageInterfaceCacheChecker;
 pub use self::rings_core::prelude::MessageRelay;

--- a/node/src/processor.rs
+++ b/node/src/processor.rs
@@ -33,8 +33,6 @@ use crate::prelude::rings_core::message::Encoder;
 use crate::prelude::rings_core::message::Message;
 use crate::prelude::rings_core::message::PayloadSender;
 use crate::prelude::rings_core::prelude::uuid;
-use crate::prelude::rings_core::prelude::web3::contract::tokens::Tokenizable;
-use crate::prelude::rings_core::prelude::web3::ethabi::Token;
 use crate::prelude::rings_core::storage::PersistenceStorage;
 use crate::prelude::rings_core::swarm::MeasureImpl;
 use crate::prelude::rings_core::swarm::Swarm;
@@ -589,7 +587,7 @@ impl Processor {
 #[derive(Clone)]
 pub struct Peer {
     /// web3 did of a peer.
-    pub did: Token,
+    pub did: String,
     /// the connection.
     pub connection: Connection,
 }
@@ -597,7 +595,7 @@ pub struct Peer {
 impl From<(Did, Connection)> for Peer {
     fn from((did, connection): (Did, Connection)) -> Self {
         Self {
-            did: did.into_token(),
+            did: did.to_string(),
             connection,
         }
     }
@@ -606,7 +604,7 @@ impl From<(Did, Connection)> for Peer {
 impl From<&(Did, Connection)> for Peer {
     fn from((did, connection): &(Did, Connection)) -> Self {
         Self {
-            did: did.into_token(),
+            did: did.to_string(),
             connection: connection.clone(),
         }
     }
@@ -616,8 +614,8 @@ impl Peer {
     /// convert peer to response peer
     pub fn into_response_peer(&self) -> rings_rpc::response::Peer {
         rings_rpc::response::Peer {
-            did: self.did.clone().into_token().to_string(),
-            cid: self.did.clone().into_token().to_string(),
+            did: self.did.clone(),
+            cid: self.did.clone(),
             state: format!("{:?}", self.connection.webrtc_connection_state()),
         }
     }

--- a/node/src/tests/wasm/browser.rs
+++ b/node/src/tests/wasm/browser.rs
@@ -142,7 +142,7 @@ async fn test_get_address_from_hex_pubkey() {
     assert!(addr_result.is_ok(), "addr_result is error");
     let addr = addr_result.ok().unwrap();
     assert!(
-        addr.eq_ignore_ascii_case("fada88633e01d2f6704a7f2a6ebc57263aca6978"),
+        addr.eq_ignore_ascii_case("0xfada88633e01d2f6704a7f2a6ebc57263aca6978"),
         "got addr {:?}",
         addr
     );
@@ -150,7 +150,7 @@ async fn test_get_address_from_hex_pubkey() {
 
 #[wasm_bindgen_test]
 async fn test_get_address() {
-    let expect_address = "8b98cf912975b4b6b67ce94882fc25c210a60a60";
+    let expect_address = "0x8b98cf912975b4b6b67ce94882fc25c210a60a60";
     let got_address = browser::get_address(
         "9z1ZTaGocNSAu3DSqGKR6Dqt214X4dXucVd6C53EgqBK",
         browser::AddressType::Ed25519,
@@ -163,12 +163,9 @@ async fn test_get_address() {
         got_address,
         expect_address
     );
-    let got_address = browser::get_address(
-        format!("0x{}", expect_address).as_str(),
-        browser::AddressType::DEFAULT,
-    )
-    .ok()
-    .unwrap();
+    let got_address = browser::get_address(expect_address, browser::AddressType::DEFAULT)
+        .ok()
+        .unwrap();
 
     assert!(
         got_address.eq_ignore_ascii_case(expect_address),

--- a/node/src/tests/wasm/processor.rs
+++ b/node/src/tests/wasm/processor.rs
@@ -11,7 +11,6 @@ use crate::prelude::rings_core::async_trait;
 use crate::prelude::rings_core::dht::TStabilize;
 use crate::prelude::rings_core::message::MessageCallback;
 use crate::prelude::rings_core::utils;
-use crate::prelude::web3::contract::tokens::Tokenizable;
 use crate::prelude::*;
 use crate::processor;
 use crate::processor::*;
@@ -123,8 +122,8 @@ async fn test_processor_handshake_and_msg() {
     let test_text4 = "test4";
     let test_text5 = "test5";
 
-    let p1_addr = p1.did().into_token().to_string();
-    let p2_addr = p2.did().into_token().to_string();
+    let p1_addr = p1.did().to_string();
+    let p2_addr = p2.did().to_string();
     console_log!("p1_addr: {}", p1_addr);
     console_log!("p2_addr: {}", p2_addr);
 
@@ -218,7 +217,7 @@ async fn test_processor_connect_with_did() {
     assert!(
         p1_peers
             .iter()
-            .any(|p| p.did.to_string().eq(&p2.did().into_token().to_string())),
+            .any(|p| p.did.to_string().eq(&p2.did().to_string())),
         "p2 not in p1's peer list"
     );
 
@@ -242,10 +241,9 @@ async fn test_processor_connect_with_did() {
     console_log!("check peers");
     let peers = p1.list_peers().await.unwrap();
     assert!(
-        peers.iter().any(|p| p
-            .did
-            .to_string()
-            .eq(p3.did().into_token().to_string().as_str())),
+        peers
+            .iter()
+            .any(|p| p.did.to_string().eq(p3.did().to_string().as_str())),
         "peer list dose NOT contains p3 address"
     );
     console_log!("processor_close_all_connections");


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

## :large_blue_circle: What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
* Remove web3 package dependency. Use specific ethereum-type and tiny-keccak packages.
* Fix the display format for Did. Now it has a `0x` prefix when display.

## :brown_circle: What is the current behavior? (You can also link to an open issue here)
The web3 is a huge package. Rings-core crate do not need all the features of it.

## :green_circle: What is the new behavior (if this is a feature change)?
It is replaced by the sub-dependencies ethereum-type and tiny-keccak.

## :radioactive: Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No breaking change.

## :information_source: Other information

Closes #issue
