### PR TITLE
ci: enable and fix DummyTransport in tests

### DIFF
--- a/core/src/message/handlers/connection.rs
+++ b/core/src/message/handlers/connection.rs
@@ -941,9 +941,6 @@ pub mod tests {
         let ev1 = node1.listen_once().await.unwrap().0;
         assert!(matches!(ev1.data, Message::LeaveDHT(LeaveDHT{did}) if did == node2.did()));
 
-        #[cfg(not(feature = "wasm"))]
-        node2.disconnect(node1.did()).await.unwrap();
-
         for _ in 1..10 {
             println!("wait 3 seconds for node2's transport 2to1 closing");
             sleep(Duration::from_secs(3)).await;
@@ -957,6 +954,13 @@ pub mod tests {
                 break;
             }
         }
+
+        // state change to Disconnected
+        let ev2 = node2.listen_once().await.unwrap().0;
+        assert_eq!(ev2.addr, node2.did());
+        assert!(matches!(ev2.data, Message::LeaveDHT(LeaveDHT{did}) if did == node1.did()));
+
+        // state change to Closed
         let ev2 = node2.listen_once().await.unwrap().0;
         assert_eq!(ev2.addr, node2.did());
         assert!(matches!(ev2.data, Message::LeaveDHT(LeaveDHT{did}) if did == node1.did()));

--- a/core/src/types/mod.rs
+++ b/core/src/types/mod.rs
@@ -4,13 +4,17 @@
 pub mod channel;
 
 use rings_transport::connection_ref::ConnectionRef;
+#[cfg(feature = "dummy")]
+pub use rings_transport::connections::DummyConnection as ConnectionOwner;
+#[cfg(feature = "dummy")]
+pub use rings_transport::connections::DummyTransport as Transport;
 #[cfg(feature = "wasm")]
 pub use rings_transport::connections::WebSysWebrtcConnection as ConnectionOwner;
 #[cfg(feature = "wasm")]
 pub use rings_transport::connections::WebSysWebrtcTransport as Transport;
-#[cfg(not(feature = "wasm"))]
+#[cfg(all(not(feature = "wasm"), not(feature = "dummy")))]
 pub use rings_transport::connections::WebrtcConnection as ConnectionOwner;
-#[cfg(not(feature = "wasm"))]
+#[cfg(all(not(feature = "wasm"), not(feature = "dummy")))]
 pub use rings_transport::connections::WebrtcTransport as Transport;
 
 pub type Connection = ConnectionRef<ConnectionOwner>;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

## :large_blue_circle: What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
We forgot to enable DummyTransport in the dummy tests previously. This PR has now enabled it.
Additionally, we also fixed two bugs in DummyTransport:
1. The state changing of closing was incorrect. It should first change to disconnected before becoming closed. And this process should be skipped if the state is already closed.
2. The global hub CBS and CONNS was using cid as a key, which caused conflicts when connecting multiple nodes together since different connections with the same cid could appear on different nodes. We have changed it to use a random number generated by each connection as the key instead.

## :brown_circle: What is the current behavior? (You can also link to an open issue here)
The DummyTransport is not enabled in dummy tests and there are bugs.

## :green_circle: What is the new behavior (if this is a feature change)?
Bug fixed. Enabled.

## :radioactive: Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No breaking change

## :information_source: Other information

Closes #issue
