### PR TITLE
feature: split Transaction from MessagePayload

### DIFF
--- a/core/src/chunk.rs
+++ b/core/src/chunk.rs
@@ -64,7 +64,7 @@ pub struct ChunkMeta {
     /// Created time
     pub ts_ms: u128,
     /// Time to live
-    pub ttl_ms: usize,
+    pub ttl_ms: u64,
 }
 
 impl Default for ChunkMeta {

--- a/core/src/consts.rs
+++ b/core/src/consts.rs
@@ -1,10 +1,10 @@
 //! Constant variables.
 ///
 /// default ttl in ms
-pub const DEFAULT_TTL_MS: usize = 300 * 1000;
-pub const MAX_TTL_MS: usize = DEFAULT_TTL_MS * 10;
+pub const DEFAULT_TTL_MS: u64 = 300 * 1000;
+pub const MAX_TTL_MS: u64 = DEFAULT_TTL_MS * 10;
 pub const TS_OFFSET_TOLERANCE_MS: u128 = 3000;
-pub const DEFAULT_SESSION_TTL_MS: usize = 30 * 24 * 3600 * 1000;
+pub const DEFAULT_SESSION_TTL_MS: u64 = 30 * 24 * 3600 * 1000;
 pub const TRANSPORT_MTU: usize = 60000;
 pub const TRANSPORT_MAX_SIZE: usize = TRANSPORT_MTU * 16;
 pub const VNODE_DATA_MAX_LEN: usize = 1024;

--- a/core/src/dht/vnode.rs
+++ b/core/src/dht/vnode.rs
@@ -3,7 +3,6 @@ use std::cmp::max;
 use std::str::FromStr;
 
 use num_bigint::BigUint;
-use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -16,6 +15,7 @@ use crate::error::Result;
 use crate::message::Encoded;
 use crate::message::Encoder;
 use crate::message::MessagePayload;
+use crate::message::MessageVerificationExt;
 
 /// VNode Types
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -108,12 +108,10 @@ impl VNodeOperation {
     }
 }
 
-impl<T> TryFrom<MessagePayload<T>> for VirtualNode
-where T: Serialize + DeserializeOwned
-{
+impl TryFrom<MessagePayload> for VirtualNode {
     type Error = Error;
-    fn try_from(msg: MessagePayload<T>) -> Result<Self> {
-        let did = BigUint::from(msg.addr) + BigUint::from(1u16);
+    fn try_from(msg: MessagePayload) -> Result<Self> {
+        let did = BigUint::from(msg.signer()) + BigUint::from(1u16);
         let data = msg.encode()?;
         Ok(Self {
             did: did.into(),

--- a/core/src/ecc/mod.rs
+++ b/core/src/ecc/mod.rs
@@ -272,10 +272,10 @@ impl PublicKey {
 }
 
 /// Recover PublicKey from RawMessage using signature.
-pub fn recover<S>(message: &str, signature: S) -> Result<PublicKey>
+pub fn recover<S>(message: &[u8], signature: S) -> Result<PublicKey>
 where S: AsRef<[u8]> {
     let sig_bytes: SigBytes = signature.as_ref().try_into()?;
-    let message_hash: [u8; 32] = keccak256(message.as_bytes());
+    let message_hash: [u8; 32] = keccak256(message);
     recover_hash(&message_hash, &sig_bytes)
 }
 
@@ -353,7 +353,7 @@ pub mod tests {
     fn test_recover() {
         let key = SecretKey::random();
         let pubkey1 = key.pubkey();
-        let pubkey2 = recover("hello", key.sign("hello")).unwrap();
+        let pubkey2 = recover("hello".as_bytes(), key.sign("hello")).unwrap();
         assert_eq!(pubkey1, pubkey2);
     }
 

--- a/core/src/ecc/signers/ed25519.rs
+++ b/core/src/ecc/signers/ed25519.rs
@@ -6,7 +6,7 @@ use crate::ecc::PublicKeyAddress;
 
 /// ref <https://www.rfc-editor.org/rfc/rfc8709>
 pub fn verify(
-    msg: &str,
+    msg: &[u8],
     address: &PublicKeyAddress,
     sig: impl AsRef<[u8]>,
     pubkey: PublicKey,
@@ -22,7 +22,7 @@ pub fn verify(
         TryInto::<ed25519_dalek::PublicKey>::try_into(pubkey),
         ed25519_dalek::Signature::from_bytes(&sig_data),
     ) {
-        match p.verify(msg.as_bytes(), &s) {
+        match p.verify(msg, &s) {
             Ok(()) => true,
             Err(_) => false,
         }
@@ -54,6 +54,11 @@ mod test {
             PublicKey::try_from_b58t("9z1ZTaGocNSAu3DSqGKR6Dqt214X4dXucVd6C53EgqBK").unwrap();
         let sig_b58 = "2V1AR5byk4a4CkVmFRWU1TVs3ns2CGkuq6xgGju1huGQGq5hGkiHUDjEaJJaL2txfqCSGnQW55jUJpcjKFkZEKq";
         let sig: Vec<u8> = base58::FromBase58::from_base58(sig_b58).unwrap();
-        assert!(self::verify(msg, &signer.address(), sig.as_slice(), signer))
+        assert!(self::verify(
+            msg.as_bytes(),
+            &signer.address(),
+            sig.as_slice(),
+            signer
+        ))
     }
 }

--- a/core/src/ecc/signers/secp256k1.rs
+++ b/core/src/ecc/signers/secp256k1.rs
@@ -7,7 +7,7 @@ use crate::ecc::SecretKey;
 use crate::error::Result;
 
 /// sign function passing raw message parameter.
-pub fn sign_raw(sec: SecretKey, msg: &str) -> [u8; 65] {
+pub fn sign_raw(sec: SecretKey, msg: &[u8]) -> [u8; 65] {
     sign(sec, &hash(msg))
 }
 
@@ -17,18 +17,18 @@ pub fn sign(sec: SecretKey, hash: &[u8; 32]) -> [u8; 65] {
 }
 
 /// generate hash data from message.
-pub fn hash(msg: &str) -> [u8; 32] {
-    keccak256(msg.as_bytes())
+pub fn hash(msg: &[u8]) -> [u8; 32] {
+    keccak256(msg)
 }
 
 /// recover public key from message and signature.
-pub fn recover(msg: &str, sig: impl AsRef<[u8]>) -> Result<PublicKey> {
+pub fn recover(msg: &[u8], sig: impl AsRef<[u8]>) -> Result<PublicKey> {
     let sig_byte: [u8; 65] = sig.as_ref().try_into()?;
     crate::ecc::recover(msg, sig_byte)
 }
 
 /// verify signature with message and address.
-pub fn verify(msg: &str, address: &PublicKeyAddress, sig: impl AsRef<[u8]>) -> bool {
+pub fn verify(msg: &[u8], address: &PublicKeyAddress, sig: impl AsRef<[u8]>) -> bool {
     if let Ok(p) = recover(msg, sig) {
         p.address() == *address
     } else {
@@ -48,7 +48,7 @@ mod test {
                 .unwrap();
 
         let msg = "hello";
-        let h = self::hash(msg);
+        let h = self::hash(msg.as_bytes());
         let sig = self::sign(key, &h);
         assert_eq!(sig, key.sign(msg));
     }

--- a/core/src/message/handlers/custom.rs
+++ b/core/src/message/handlers/custom.rs
@@ -2,7 +2,6 @@ use async_trait::async_trait;
 
 use crate::error::Result;
 use crate::message::types::CustomMessage;
-use crate::message::types::Message;
 use crate::message::HandleMsg;
 use crate::message::MessageHandler;
 use crate::message::MessageHandlerEvent;
@@ -13,7 +12,7 @@ use crate::message::MessagePayload;
 impl HandleMsg<CustomMessage> for MessageHandler {
     async fn handle(
         &self,
-        ctx: &MessagePayload<Message>,
+        ctx: &MessagePayload,
         _: &CustomMessage,
     ) -> Result<Vec<MessageHandlerEvent>> {
         if self.dht.did != ctx.relay.destination {

--- a/core/src/message/handlers/dht.rs
+++ b/core/src/message/handlers/dht.rs
@@ -60,7 +60,7 @@ macro_rules! handle_multi_actions {
 #[cfg_attr(not(feature = "wasm"), async_recursion)]
 pub async fn handle_dht_events(
     act: &PeerRingAction,
-    ctx: &MessagePayload<Message>,
+    ctx: &MessagePayload,
 ) -> Result<Vec<MessageHandlerEvent>> {
     match act {
         PeerRingAction::None => Ok(vec![]),

--- a/core/src/message/handlers/storage.rs
+++ b/core/src/message/handlers/storage.rs
@@ -105,7 +105,7 @@ pub(super) async fn handle_storage_store_act(swarm: &Swarm, act: PeerRingAction)
 #[cfg_attr(feature = "wasm", async_recursion(?Send))]
 #[cfg_attr(not(feature = "wasm"), async_recursion)]
 pub(super) async fn handle_storage_operate_act(
-    ctx: &MessagePayload<Message>,
+    ctx: &MessagePayload,
     act: &PeerRingAction,
 ) -> Result<Vec<MessageHandlerEvent>> {
     match act {
@@ -178,7 +178,7 @@ impl HandleMsg<SearchVNode> for MessageHandler {
     /// If a VNode is storead local, it will response immediately.(See Chordstorageinterface::storage_fetch)
     async fn handle(
         &self,
-        ctx: &MessagePayload<Message>,
+        ctx: &MessagePayload,
         msg: &SearchVNode,
     ) -> Result<Vec<MessageHandlerEvent>> {
         // For relay message, set redundant to 1
@@ -207,7 +207,7 @@ impl HandleMsg<SearchVNode> for MessageHandler {
 impl HandleMsg<FoundVNode> for MessageHandler {
     async fn handle(
         &self,
-        ctx: &MessagePayload<Message>,
+        ctx: &MessagePayload,
         msg: &FoundVNode,
     ) -> Result<Vec<MessageHandlerEvent>> {
         if self.dht.did != ctx.relay.destination {
@@ -225,7 +225,7 @@ impl HandleMsg<FoundVNode> for MessageHandler {
 impl HandleMsg<VNodeOperation> for MessageHandler {
     async fn handle(
         &self,
-        ctx: &MessagePayload<Message>,
+        ctx: &MessagePayload,
         msg: &VNodeOperation,
     ) -> Result<Vec<MessageHandlerEvent>> {
         // For relay message, set redundant to 1
@@ -241,7 +241,7 @@ impl HandleMsg<SyncVNodeWithSuccessor> for MessageHandler {
     // received remote sync vnode request
     async fn handle(
         &self,
-        _ctx: &MessagePayload<Message>,
+        _ctx: &MessagePayload,
         msg: &SyncVNodeWithSuccessor,
     ) -> Result<Vec<MessageHandlerEvent>> {
         let mut events = vec![];
@@ -296,7 +296,7 @@ mod test {
             .unwrap();
         let ev = node2.listen_once().await.unwrap().0;
         assert!(matches!(
-            ev.data,
+            ev.transaction.data()?,
             Message::OperateVNode(VNodeOperation::Overwrite(x)) if x.did == vid
         ));
 
@@ -315,13 +315,13 @@ mod test {
         let ev = node2.listen_once().await.unwrap().0;
         // node2 received search vnode request
         assert!(matches!(
-            ev.data,
+            ev.transaction.data()?,
             Message::SearchVNode(x) if x.vid == vid
         ));
 
         let ev = node1.listen_once().await.unwrap().0;
         assert!(matches!(
-            ev.data,
+            ev.transaction.data()?,
             Message::FoundVNode(x) if x.data[0].did == vid
         ));
 
@@ -375,7 +375,7 @@ mod test {
 
         let ev = node2.listen_once().await.unwrap().0;
         assert!(matches!(
-            ev.data,
+            ev.transaction.data()?,
             Message::OperateVNode(VNodeOperation::Extend(VirtualNode { did, data, kind: VNodeType::Data }))
                 if did == vid && data == vec!["111".to_string().encode()?]
         ));
@@ -388,7 +388,7 @@ mod test {
         .unwrap();
         let ev = node2.listen_once().await.unwrap().0;
         assert!(matches!(
-            ev.data,
+            ev.transaction.data()?,
             Message::OperateVNode(VNodeOperation::Extend(VirtualNode { did, data, kind: VNodeType::Data }))
                 if did == vid && data == vec!["222".to_string().encode()?]
         ));
@@ -407,13 +407,13 @@ mod test {
 
         // node2 received search vnode request
         assert!(matches!(
-            ev.data,
+            ev.transaction.data()?,
             Message::SearchVNode(x) if x.vid == vid
         ));
         let ev = node1.listen_once().await.unwrap().0;
 
         assert!(matches!(
-            ev.data,
+            ev.transaction.data()?,
             Message::FoundVNode(x) if x.data[0].did == vid
         ));
 
@@ -437,7 +437,7 @@ mod test {
 
         let ev = node2.listen_once().await.unwrap().0;
         assert!(matches!(
-            ev.data,
+            ev.transaction.data()?,
             Message::OperateVNode(VNodeOperation::Extend(VirtualNode { did, data, kind: VNodeType::Data }))
                 if did == vid && data == vec!["333".to_string().encode()?]
         ));
@@ -452,13 +452,13 @@ mod test {
         let ev = node2.listen_once().await.unwrap().0;
         // node2 received search vnode request
         assert!(matches!(
-            ev.data,
+            ev.transaction.data()?,
             Message::SearchVNode(x) if x.vid == vid
         ));
 
         let ev = node1.listen_once().await.unwrap().0;
         assert!(matches!(
-            ev.data,
+            ev.transaction.data()?,
             Message::FoundVNode(x) if x.data[0].did == vid
         ));
 

--- a/core/src/message/mod.rs
+++ b/core/src/message/mod.rs
@@ -10,8 +10,8 @@ pub use payload::encode_data_gzip;
 pub use payload::from_gzipped_data;
 pub use payload::gzip_data;
 pub use payload::MessagePayload;
-pub use payload::OriginVerificationGen;
 pub use payload::PayloadSender;
+pub use payload::Transaction;
 
 pub mod types;
 pub use types::*;
@@ -29,3 +29,4 @@ pub use handlers::ValidatorFn;
 
 mod protocols;
 pub use protocols::MessageRelay;
+pub use protocols::MessageVerificationExt;

--- a/core/src/message/payload.rs
+++ b/core/src/message/payload.rs
@@ -16,17 +16,15 @@ use super::encoder::Encoded;
 use super::encoder::Encoder;
 use super::protocols::MessageRelay;
 use super::protocols::MessageVerification;
-use crate::consts::DEFAULT_TTL_MS;
-use crate::consts::MAX_TTL_MS;
-use crate::consts::TS_OFFSET_TOLERANCE_MS;
+use super::protocols::MessageVerificationExt;
 use crate::dht::Chord;
 use crate::dht::Did;
 use crate::dht::PeerRing;
 use crate::dht::PeerRingAction;
+use crate::ecc::keccak256;
 use crate::error::Error;
 use crate::error::Result;
 use crate::session::SessionSk;
-use crate::utils::get_epoch_ms;
 
 /// Compresses the given data byte slice using the gzip algorithm with the specified compression level.
 pub fn encode_data_gzip(data: &Bytes, level: u8) -> Result<Bytes> {
@@ -61,13 +59,30 @@ where T: DeserializeOwned {
     Ok(m)
 }
 
-/// An enumeration of options for generating origin verification or stick verification.
-/// Verification can be Stick Verification or origin verification.
-/// When MessagePayload created, Origin Verification is always generated.
-/// and if OriginVerificationGen is stick, it can including existing stick ov
-pub enum OriginVerificationGen {
-    Origin,
-    Stick(MessageVerification),
+fn hash_transaction(destination: Did, tx_id: uuid::Uuid, data: &[u8]) -> [u8; 32] {
+    let mut msg = vec![];
+
+    msg.extend_from_slice(destination.as_bytes());
+    msg.extend_from_slice(tx_id.as_bytes());
+    msg.extend_from_slice(data);
+
+    keccak256(&msg)
+}
+
+#[derive(Derivative, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[derivative(Debug)]
+pub struct Transaction {
+    /// The destination of this message.
+    pub destination: Did,
+    /// The transaction ID.
+    /// Remote peer should use same tx_id when response.
+    pub tx_id: uuid::Uuid,
+    /// data
+    pub data: Vec<u8>,
+    /// This field hold a signature from a node,
+    /// which is used to prove that the transaction was created by that node.
+    #[derivative(Debug = "ignore")]
+    pub verification: MessageVerification,
 }
 
 /// All messages transmitted in RingsNetwork should be wrapped by MessagePayload.
@@ -75,128 +90,82 @@ pub enum OriginVerificationGen {
 /// and origin verification.
 #[derive(Derivative, Deserialize, Serialize, Clone, PartialEq, Eq)]
 #[derivative(Debug)]
-pub struct MessagePayload<T> {
+pub struct MessagePayload {
     /// Payload data
-    pub data: T,
-    /// The transaction ID of payload.
-    /// Remote peer should use same tx_id when response.
-    pub tx_id: uuid::Uuid,
-    /// The did of payload account, usually it's last sender.
-    pub addr: Did,
+    pub transaction: Transaction,
     /// Relay records the transport path of message.
     /// And can also help message sender to find the next hop.
     pub relay: MessageRelay,
     /// This field hold a signature from a node,
-    /// which is used to prove that the message was sent from that node.
+    /// which is used to prove that the transaction was created by that node.
     #[derivative(Debug = "ignore")]
     pub verification: MessageVerification,
-    /// Same as verification, but the signature was from the original sender.
-    #[derivative(Debug = "ignore")]
-    pub origin_verification: MessageVerification,
 }
 
-impl<T> MessagePayload<T>
-where T: Serialize + DeserializeOwned
-{
-    /// Create new instance
-    pub fn new(
+impl Transaction {
+    pub fn new<T>(
+        destination: Did,
+        tx_id: uuid::Uuid,
         data: T,
         session_sk: &SessionSk,
-        origin_verification_gen: OriginVerificationGen,
-        relay: MessageRelay,
-    ) -> Result<Self> {
-        let ts_ms = get_epoch_ms();
-        let ttl_ms = DEFAULT_TTL_MS;
-        let msg = &MessageVerification::pack_msg(&data, ts_ms, ttl_ms)?;
-        let tx_id = uuid::Uuid::new_v4();
-        let addr = session_sk.account_did();
-        let verification = MessageVerification {
-            session: session_sk.session(),
-            sig: session_sk.sign(msg)?,
-            ttl_ms,
-            ts_ms,
-        };
-        // If origin_verification_gen is set to Origin, simply clone it into.
-        let origin_verification = match origin_verification_gen {
-            OriginVerificationGen::Origin => verification.clone(),
-            OriginVerificationGen::Stick(ov) => ov,
-        };
-
+    ) -> Result<Self>
+    where
+        T: Serialize,
+    {
+        let data = bincode::serialize(&data).map_err(Error::BincodeSerialize)?;
+        let msg_hash = hash_transaction(destination, tx_id, &data);
+        let verification = MessageVerification::new(&msg_hash, session_sk)?;
         Ok(Self {
-            data,
+            destination,
             tx_id,
-            addr,
+            data,
             verification,
-            origin_verification,
-            relay,
         })
     }
 
-    /// Create new Payload for send
-    pub fn new_send(
+    pub fn data<T>(&self) -> Result<T>
+    where T: DeserializeOwned {
+        bincode::deserialize(&self.data).map_err(Error::BincodeDeserialize)
+    }
+}
+
+impl MessagePayload {
+    /// Create new instance
+    pub fn new(
+        transaction: Transaction,
+        session_sk: &SessionSk,
+        relay: MessageRelay,
+    ) -> Result<Self> {
+        let msg_hash = hash_transaction(
+            transaction.destination,
+            transaction.tx_id,
+            &transaction.data,
+        );
+        let verification = MessageVerification::new(&msg_hash, session_sk)?;
+        Ok(Self {
+            transaction,
+            relay,
+            verification,
+        })
+    }
+
+    pub fn new_send<T>(
         data: T,
         session_sk: &SessionSk,
         next_hop: Did,
         destination: Did,
-    ) -> Result<Self> {
-        let relay = MessageRelay::new(vec![session_sk.account_did()], next_hop, destination);
-        Self::new(data, session_sk, OriginVerificationGen::Origin, relay)
-    }
-
-    /// Checks whether the payload is expired.
-    pub fn is_expired(&self) -> bool {
-        if self.verification.ttl_ms > MAX_TTL_MS {
-            return false;
-        }
-
-        if self.origin_verification.ttl_ms > MAX_TTL_MS {
-            return false;
-        }
-
-        let now = get_epoch_ms();
-
-        if self.verification.ts_ms - TS_OFFSET_TOLERANCE_MS > now {
-            return false;
-        }
-
-        if self.origin_verification.ts_ms - TS_OFFSET_TOLERANCE_MS > now {
-            return false;
-        }
-
-        now > self.verification.ts_ms + self.verification.ttl_ms as u128
-            && now > self.origin_verification.ts_ms + self.origin_verification.ttl_ms as u128
-    }
-
-    /// Verifies that the payload is not expired and that the signature is valid.
-    pub fn verify(&self) -> bool {
-        tracing::debug!("verifying payload: {:?}", self.tx_id);
-
-        if self.is_expired() {
-            tracing::warn!("message expired");
-            return false;
-        }
-
-        if Some(self.relay.origin_sender()) != self.origin_account_did().ok() {
-            tracing::warn!("sender is not origin_verification generator");
-            return false;
-        }
-
-        self.verification.verify(&self.data) && self.origin_verification.verify(&self.data)
-    }
-
-    /// Get Did from the origin verification.
-    pub fn origin_account_did(&self) -> Result<Did> {
-        Ok(self
-            .origin_verification
-            .session
-            .account_pubkey()?
-            .address()
-            .into())
-    }
-
-    /// Get did from sender verification.
-    pub fn account_did(&self) -> Result<Did> {
-        Ok(self.verification.session.account_pubkey()?.address().into())
+    ) -> Result<Self>
+    where
+        T: Serialize,
+    {
+        let tx_id = uuid::Uuid::new_v4();
+        let transaction = Transaction::new(destination, tx_id, data, session_sk)?;
+        let relay = MessageRelay::new(
+            vec![session_sk.account_did()],
+            next_hop,
+            transaction.destination,
+        );
+        Self::new(transaction, session_sk, relay)
     }
 
     /// Deserializes a `MessagePayload` instance from the given binary data.
@@ -210,29 +179,40 @@ where T: Serialize + DeserializeOwned
             .map(Bytes::from)
             .map_err(Error::BincodeSerialize)
     }
+}
 
-    /// Did of Sender
-    pub fn sender(&self) -> Result<Did> {
-        self.account_did()
+impl MessageVerificationExt for Transaction {
+    fn verification_data(&self) -> Result<Vec<u8>> {
+        Ok(hash_transaction(self.destination, self.tx_id, &self.data).to_vec())
     }
 
-    /// Did of Origin
-    pub fn origin(&self) -> Result<Did> {
-        self.origin_account_did()
+    fn verification(&self) -> &MessageVerification {
+        &self.verification
     }
 }
 
-impl<T> Encoder for MessagePayload<T>
-where T: Serialize + DeserializeOwned
-{
+impl MessageVerificationExt for MessagePayload {
+    fn verification_data(&self) -> Result<Vec<u8>> {
+        Ok(hash_transaction(
+            self.transaction.destination,
+            self.transaction.tx_id,
+            &self.transaction.data,
+        )
+        .to_vec())
+    }
+
+    fn verification(&self) -> &MessageVerification {
+        &self.verification
+    }
+}
+
+impl Encoder for MessagePayload {
     fn encode(&self) -> Result<Encoded> {
         self.to_bincode()?.encode()
     }
 }
 
-impl<T> Decoder for MessagePayload<T>
-where T: Serialize + DeserializeOwned
-{
+impl Decoder for MessagePayload {
     fn from_encoded(encoded: &Encoded) -> Result<Self> {
         let v: Bytes = encoded.decode()?;
         Self::from_bincode(&v)
@@ -242,15 +222,13 @@ where T: Serialize + DeserializeOwned
 /// Trait of PayloadSender
 #[cfg_attr(feature = "wasm", async_trait(?Send))]
 #[cfg_attr(not(feature = "wasm"), async_trait)]
-pub trait PayloadSender<T>
-where T: Clone + Serialize + DeserializeOwned + Send + Sync + 'static
-{
+pub trait PayloadSender {
     /// Get the session sk
     fn session_sk(&self) -> &SessionSk;
     /// Get access to DHT.
     fn dht(&self) -> Arc<PeerRing>;
     /// Send a message payload to a specified DID.
-    async fn do_send_payload(&self, did: Did, payload: MessagePayload<T>) -> Result<()>;
+    async fn do_send_payload(&self, did: Did, payload: MessagePayload) -> Result<()>;
     /// Infer the next hop for a message by calling `dht.find_successor()`.
     fn infer_next_hop(&self, next_hop: Option<Did>, destination: Did) -> Result<Did> {
         if let Some(next_hop) = next_hop {
@@ -264,78 +242,71 @@ where T: Clone + Serialize + DeserializeOwned + Send + Sync + 'static
         }
     }
     /// Alias for `do_send_payload` that sets the next hop to `payload.relay.next_hop`.
-    async fn send_payload(&self, payload: MessagePayload<T>) -> Result<()> {
+    async fn send_payload(&self, payload: MessagePayload) -> Result<()> {
         self.do_send_payload(payload.relay.next_hop, payload).await
     }
 
-    /// Send a message to a specified destination.
-    async fn send_message(&self, msg: T, destination: Did) -> Result<uuid::Uuid> {
-        let next_hop = self.infer_next_hop(None, destination)?;
-        let payload = MessagePayload::new_send(msg, self.session_sk(), next_hop, destination)?;
-        self.send_payload(payload.clone()).await?;
-        Ok(payload.tx_id)
-    }
-
     /// Send a message to a specified destination by specified next hop.
-    async fn send_message_by_hop(
+    async fn send_message_by_hop<T>(
         &self,
         msg: T,
         destination: Did,
         next_hop: Did,
-    ) -> Result<uuid::Uuid> {
+    ) -> Result<uuid::Uuid>
+    where
+        T: Serialize + Send,
+    {
         let payload = MessagePayload::new_send(msg, self.session_sk(), next_hop, destination)?;
-        self.send_payload(payload.clone()).await?;
-        Ok(payload.tx_id)
+        let tx_id = payload.transaction.tx_id;
+        self.send_payload(payload).await?;
+        Ok(tx_id)
     }
 
+    /// Send a message to a specified destination.
+    async fn send_message<T>(&self, msg: T, destination: Did) -> Result<uuid::Uuid>
+    where T: Serialize + Send {
+        let next_hop = self.infer_next_hop(None, destination)?;
+        self.send_message_by_hop(msg, destination, next_hop).await
+    }
     /// Send a direct message to a specified destination.
-    async fn send_direct_message(&self, msg: T, destination: Did) -> Result<uuid::Uuid> {
-        let payload = MessagePayload::new_send(msg, self.session_sk(), destination, destination)?;
-        self.send_payload(payload.clone()).await?;
-        Ok(payload.tx_id)
+    async fn send_direct_message<T>(&self, msg: T, destination: Did) -> Result<uuid::Uuid>
+    where T: Serialize + Send {
+        self.send_message_by_hop(msg, destination, destination)
+            .await
     }
 
     /// Send a report message to a specified destination.
-    async fn send_report_message(&self, payload: &MessagePayload<T>, msg: T) -> Result<()> {
+    async fn send_report_message<T>(&self, payload: &MessagePayload, msg: T) -> Result<()>
+    where T: Serialize + Send {
         let relay = payload.relay.report(self.dht().did)?;
 
-        let mut pl =
-            MessagePayload::new(msg, self.session_sk(), OriginVerificationGen::Origin, relay)?;
-        pl.tx_id = payload.tx_id;
+        let transaction = Transaction::new(
+            relay.destination,
+            payload.transaction.tx_id,
+            msg,
+            self.session_sk(),
+        )?;
 
+        let pl = MessagePayload::new(transaction, self.session_sk(), relay)?;
         self.send_payload(pl).await
     }
 
     /// Forward a payload message by relay.
     /// It just create a new payload, cloned data, resigned with session and send
-    async fn forward_by_relay(
-        &self,
-        payload: &MessagePayload<T>,
-        relay: MessageRelay,
-    ) -> Result<()> {
-        let mut new_pl = MessagePayload::new(
-            payload.data.clone(),
-            self.session_sk(),
-            OriginVerificationGen::Stick(payload.origin_verification.clone()),
-            relay,
-        )?;
-        new_pl.tx_id = payload.tx_id;
+    async fn forward_by_relay(&self, payload: &MessagePayload, relay: MessageRelay) -> Result<()> {
+        let new_pl = MessagePayload::new(payload.transaction.clone(), self.session_sk(), relay)?;
         self.send_payload(new_pl).await
     }
 
     /// Forward a payload message, with the next hop inferred by the DHT.
-    async fn forward_payload(
-        &self,
-        payload: &MessagePayload<T>,
-        next_hop: Option<Did>,
-    ) -> Result<()> {
+    async fn forward_payload(&self, payload: &MessagePayload, next_hop: Option<Did>) -> Result<()> {
         let next_hop = self.infer_next_hop(next_hop, payload.relay.destination)?;
         let relay = payload.relay.forward(self.dht().did, next_hop)?;
         self.forward_by_relay(payload, relay).await
     }
 
     /// Reset the destination to a secp DID.
-    async fn reset_destination(&self, payload: &MessagePayload<T>, next_hop: Did) -> Result<()> {
+    async fn reset_destination(&self, payload: &MessagePayload, next_hop: Did) -> Result<()> {
         let relay = payload
             .relay
             .reset_destination(next_hop)
@@ -360,7 +331,7 @@ pub mod test {
         d: bool,
     }
 
-    pub fn new_test_payload(next_hop: Did) -> MessagePayload<TestData> {
+    pub fn new_test_payload(next_hop: Did) -> MessagePayload {
         let test_data = TestData {
             a: "hello".to_string(),
             b: 111,
@@ -370,12 +341,12 @@ pub mod test {
         new_payload(test_data, next_hop)
     }
 
-    pub fn new_payload<T>(data: T, next_hop: Did) -> MessagePayload<T>
+    pub fn new_payload<T>(data: T, next_hop: Did) -> MessagePayload
     where T: Serialize + DeserializeOwned {
         let key = SecretKey::random();
         let destination = SecretKey::random().address().into();
-        let session = SessionSk::new_with_seckey(&key).unwrap();
-        MessagePayload::new_send(data, &session, next_hop, destination).unwrap()
+        let session_sk = SessionSk::new_with_seckey(&key).unwrap();
+        MessagePayload::new_send(data, &session_sk, next_hop, destination).unwrap()
     }
 
     #[test]
@@ -393,11 +364,11 @@ pub mod test {
 
         let payload = new_test_payload(next_hop);
         let gzipped_encoded_payload = payload.encode().unwrap();
-        let payload2: MessagePayload<TestData> = gzipped_encoded_payload.decode().unwrap();
+        let payload2: MessagePayload = gzipped_encoded_payload.decode().unwrap();
         assert_eq!(payload, payload2);
 
         let gunzip_encoded_payload = payload.to_bincode().unwrap().encode().unwrap();
-        let payload2: MessagePayload<TestData> = gunzip_encoded_payload.decode().unwrap();
+        let payload2: MessagePayload = gunzip_encoded_payload.decode().unwrap();
         assert_eq!(payload, payload2);
     }
 

--- a/core/src/message/protocols/mod.rs
+++ b/core/src/message/protocols/mod.rs
@@ -3,3 +3,4 @@ mod verify;
 
 pub use self::relay::MessageRelay;
 pub use self::verify::MessageVerification;
+pub use self::verify::MessageVerificationExt;

--- a/node/src/backend/extension.rs
+++ b/node/src/backend/extension.rs
@@ -135,7 +135,7 @@ impl MessageEndpoint for Extension {
     /// Handles the incoming message by passing it to the extension handlers and returning the resulting events.
     async fn handle_message(
         &self,
-        ctx: &MessagePayload<Message>,
+        ctx: &MessagePayload,
         data: &BackendMessage,
     ) -> Result<Vec<MessageHandlerEvent>> {
         let mut ret = vec![];

--- a/node/src/backend/service/http_server.rs
+++ b/node/src/backend/service/http_server.rs
@@ -127,7 +127,7 @@ impl HttpServer {
 impl MessageEndpoint for HttpServer {
     async fn handle_message(
         &self,
-        ctx: &MessagePayload<Message>,
+        ctx: &MessagePayload,
         msg: &BackendMessage,
     ) -> Result<Vec<MessageHandlerEvent>> {
         let req: HttpRequest = bincode::deserialize(&msg.data).map_err(|_| Error::DecodeError)?;

--- a/node/src/backend/service/mod.rs
+++ b/node/src/backend/service/mod.rs
@@ -30,7 +30,6 @@ use crate::error::Result;
 use crate::prelude::rings_core::chunk::Chunk;
 use crate::prelude::rings_core::chunk::ChunkList;
 use crate::prelude::rings_core::chunk::ChunkManager;
-use crate::prelude::rings_core::message::Message;
 use crate::prelude::*;
 
 /// A Backend struct contains http_server.
@@ -100,7 +99,7 @@ impl MessageCallback for Backend {
     /// And send http request to localhost through Backend http_request handler.
     async fn custom_message(
         &self,
-        ctx: &MessagePayload<Message>,
+        ctx: &MessagePayload,
         msg: &CustomMessage,
     ) -> Vec<MessageHandlerEvent> {
         let msg = msg.0.clone();
@@ -159,7 +158,7 @@ impl MessageCallback for Backend {
         }
     }
 
-    async fn builtin_message(&self, _ctx: &MessagePayload<Message>) -> Vec<MessageHandlerEvent> {
+    async fn builtin_message(&self, _ctx: &MessagePayload) -> Vec<MessageHandlerEvent> {
         vec![]
     }
 }

--- a/node/src/backend/service/text.rs
+++ b/node/src/backend/service/text.rs
@@ -18,7 +18,7 @@ pub struct TextEndpoint;
 impl MessageEndpoint for TextEndpoint {
     async fn handle_message(
         &self,
-        ctx: &MessagePayload<Message>,
+        ctx: &MessagePayload,
         data: &BackendMessage,
     ) -> Result<Vec<MessageHandlerEvent>> {
         let text = str::from_utf8(&data.data).map_err(|_| Error::InvalidMessage)?;

--- a/node/src/backend/service/utils.rs
+++ b/node/src/backend/service/utils.rs
@@ -6,7 +6,7 @@ use crate::prelude::*;
 
 /// send chunk report message
 pub async fn send_chunk_report_message(
-    ctx: &MessagePayload<Message>,
+    ctx: &MessagePayload,
     data: &[u8],
 ) -> Result<MessageHandlerEvent> {
     let mut new_bytes: Vec<u8> = Vec::with_capacity(data.len() + 1);

--- a/node/src/backend/types.rs
+++ b/node/src/backend/types.rs
@@ -157,7 +157,7 @@ pub trait MessageEndpoint {
     /// handle_message
     async fn handle_message(
         &self,
-        ctx: &MessagePayload<Message>,
+        ctx: &MessagePayload,
         data: &BackendMessage,
     ) -> Result<Vec<MessageHandlerEvent>>;
 }

--- a/node/src/jsonrpc/server.rs
+++ b/node/src/jsonrpc/server.rs
@@ -28,7 +28,6 @@ use crate::prelude::rings_core::dht::Did;
 use crate::prelude::rings_core::message::Decoder;
 use crate::prelude::rings_core::message::Encoded;
 use crate::prelude::rings_core::message::Encoder;
-use crate::prelude::rings_core::message::Message;
 use crate::prelude::rings_core::message::MessagePayload;
 use crate::prelude::rings_core::prelude::vnode::VirtualNode;
 use crate::prelude::rings_rpc;
@@ -205,7 +204,7 @@ pub(crate) async fn answer_offer(params: Params, meta: RpcMeta) -> Result<Value>
         .ok_or_else(|| Error::new(ErrorCode::InvalidParams))?;
     let encoded: Encoded = <Encoded as From<&str>>::from(offer_payload_str);
     let offer_payload =
-        MessagePayload::<Message>::from_encoded(&encoded).map_err(|_| ServerError::DecodeError)?;
+        MessagePayload::from_encoded(&encoded).map_err(|_| ServerError::DecodeError)?;
 
     let (_, answer_payload) = meta
         .processor
@@ -234,7 +233,7 @@ pub(crate) async fn accept_answer(params: Params, meta: RpcMeta) -> Result<Value
         .ok_or_else(|| Error::new(ErrorCode::InvalidParams))?;
     let encoded: Encoded = <Encoded as From<&str>>::from(answer_payload_str);
     let answer_payload =
-        MessagePayload::<Message>::from_encoded(&encoded).map_err(|_| ServerError::DecodeError)?;
+        MessagePayload::from_encoded(&encoded).map_err(|_| ServerError::DecodeError)?;
     let p: processor::Peer = meta
         .processor
         .swarm

--- a/node/src/native/endpoint/mod.rs
+++ b/node/src/native/endpoint/mod.rs
@@ -111,7 +111,7 @@ async fn jsonrpc_io_handler(
             .swarm
             .session_sk()
             .session()
-            .verify(&body, sig)
+            .verify(body.as_bytes(), sig)
             .map_err(|e| {
                 tracing::debug!("body: {:?}", body);
                 tracing::debug!("signature: {:?}", signature);

--- a/node/src/processor.rs
+++ b/node/src/processor.rs
@@ -357,8 +357,8 @@ impl Processor {
 
         let encoded_answer: Encoded = <Encoded as From<&str>>::from(&answer_payload_str);
 
-        let answer_payload = MessagePayload::<Message>::from_encoded(&encoded_answer)
-            .map_err(|_| Error::DecodeError)?;
+        let answer_payload =
+            MessagePayload::from_encoded(&encoded_answer).map_err(|_| Error::DecodeError)?;
 
         let (did, conn) = self
             .swarm
@@ -660,7 +660,7 @@ mod test {
     impl MessageCallback for MsgCallbackStruct {
         async fn custom_message(
             &self,
-            _ctx: &MessagePayload<Message>,
+            _ctx: &MessagePayload,
             msg: &CustomMessage,
         ) -> Vec<MessageHandlerEvent> {
             let text = unpack_text_message(msg).unwrap();
@@ -669,10 +669,7 @@ mod test {
             vec![]
         }
 
-        async fn builtin_message(
-            &self,
-            _ctx: &MessagePayload<Message>,
-        ) -> Vec<MessageHandlerEvent> {
+        async fn builtin_message(&self, _ctx: &MessagePayload) -> Vec<MessageHandlerEvent> {
             vec![]
         }
     }

--- a/node/src/tests/wasm/processor.rs
+++ b/node/src/tests/wasm/processor.rs
@@ -42,7 +42,7 @@ struct MsgCallbackStruct {
 impl MessageCallback for MsgCallbackStruct {
     async fn custom_message(
         &self,
-        _ctx: &MessagePayload<Message>,
+        _ctx: &MessagePayload,
         msg: &CustomMessage,
     ) -> Vec<MessageHandlerEvent> {
         let text = processor::unpack_text_message(msg).unwrap();
@@ -52,7 +52,7 @@ impl MessageCallback for MsgCallbackStruct {
         vec![]
     }
 
-    async fn builtin_message(&self, _ctx: &MessagePayload<Message>) -> Vec<MessageHandlerEvent> {
+    async fn builtin_message(&self, _ctx: &MessagePayload) -> Vec<MessageHandlerEvent> {
         vec![]
     }
 }

--- a/rpc/src/jsonrpc_client/client.rs
+++ b/rpc/src/jsonrpc_client/client.rs
@@ -80,7 +80,7 @@ impl SimpleClient {
 
         if let Some(delegated_sk) = &self.delegated_sk {
             let sig = delegated_sk
-                .sign(&request.clone())
+                .sign(request.clone().as_bytes())
                 .map_err(|e| RpcError::Client(format!("Failed to sign request: {}", e)))?;
             let encoded_sig = base64::encode(sig);
             req = req.header("X-SIGNATURE", encoded_sig);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## :large_blue_circle: What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
This PR moves the message packing and verification logic from `MessagePayload` to `Transaction`.
Now, the `MessagePayload` only works for transferring messages.
This PR also removed the generic type `T` from the `MessagePayload` struct since it does not care about the type when transferring and verifying. Instead, the `T` type was moved to the `new` method, and the data is serialized immediately upon creating the struct.

## :brown_circle: What is the current behavior? (You can also link to an open issue here)
1. The `origin_verification` field and `verification` field appear strangely in MessagePayload. 
2. When users want to create passing messages, they have to create fake or empty MessageRelay.
3. The generic type T for MessagePayload seems straightforward. And make it harder to be specified.
4. The `addr` field is ambiguous, you have to understand it from the comments.

```Rust
pub struct MessagePayload<T> {
    pub data: T,
    pub tx_id: uuid::Uuid,
    pub addr: Did,
    pub relay: MessageRelay,
    pub verification: MessageVerification,
    pub origin_verification: MessageVerification,
}
```

## :green_circle: What is the new behavior (if this is a feature change)?
The `Transaction` that is used to hold a verified message can be constructed separately.
Users can create the `MessagePayload` at a later time when they want to transfer a `Transaction`.

```Rust
pub struct Transaction {
    pub destination: Did,
    pub tx_id: uuid::Uuid,
    pub data: Vec<u8>,
    pub verification: MessageVerification,
}

pub struct MessagePayload {
    pub transaction: Transaction,
    pub relay: MessageRelay,
    pub verification: MessageVerification,
}

```

## :radioactive: Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No breaking change.

## :information_source: Other information

Closes #issue
