### PR TITLE
bugfix: make JsValue serializer JSON compatible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3415,7 +3415,7 @@ dependencies = [
  "rings-derive",
  "rings-transport",
  "serde",
- "serde-wasm-bindgen 0.5.0",
+ "serde-wasm-bindgen 0.6.1",
  "serde_json",
  "sha1",
  "sha2 0.10.6",
@@ -3483,7 +3483,7 @@ dependencies = [
  "rings-rpc",
  "rings-transport",
  "serde",
- "serde-wasm-bindgen 0.5.0",
+ "serde-wasm-bindgen 0.6.1",
  "serde_json",
  "serde_yaml",
  "thiserror",
@@ -3846,9 +3846,9 @@ dependencies = [
 
 [[package]]
 name = "serde-wasm-bindgen"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
+checksum = "17ba92964781421b6cef36bf0d7da26d201e96d84e1b10e7ae6ed416e516906d"
 dependencies = [
  "js-sys",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,10 @@ resolver = "2"
 
 [workspace.dependencies]
 js-sys = { version = "0.3.64" }
-rings-core = { version = "0.3.2", path = "core", default-features = false }
-rings-derive = { version = "0.3.2", path = "derive", default-features = false }
-rings-rpc = { version = "0.3.2", path = "rpc", default-features = false }
-rings-transport = { version = "0.3.2", path = "transport" }
+rings-core = { version = "0.3.4", path = "core", default-features = false }
+rings-derive = { version = "0.3.4", path = "derive", default-features = false }
+rings-rpc = { version = "0.3.4", path = "rpc", default-features = false }
+rings-transport = { version = "0.3.4", path = "transport" }
 serde-wasm-bindgen = { version = "0.6.1" }
 wasm-bindgen = { version = "0.2.87" }
 wasm-bindgen-futures = { version = "0.4.37" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,11 @@ resolver = "2"
 
 [workspace.dependencies]
 js-sys = { version = "0.3.64" }
-rings-core = { version = "0.3.3", path = "core", default-features = false }
-rings-derive = { version = "0.3.3", path = "derive", default-features = false }
-rings-rpc = { version = "0.3.3", path = "rpc", default-features = false }
-rings-transport = { version = "0.3.3", path = "transport" }
-serde-wasm-bindgen = { version = "0.5.0" }
+rings-core = { version = "0.3.2", path = "core", default-features = false }
+rings-derive = { version = "0.3.2", path = "derive", default-features = false }
+rings-rpc = { version = "0.3.2", path = "rpc", default-features = false }
+rings-transport = { version = "0.3.2", path = "transport" }
+serde-wasm-bindgen = { version = "0.6.1" }
 wasm-bindgen = { version = "0.2.87" }
 wasm-bindgen-futures = { version = "0.4.37" }
 wasm-bindgen-macro-support = { version = "0.2.84" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rings-core"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 authors = ["RND <dev@ringsnetwork.io>"]
 description = "Chord DHT implementation with ICE"

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -1,6 +1,5 @@
 //! Utils for ring-core
 use chrono::Utc;
-
 /// Get local utc timestamp (millisecond)
 pub fn get_epoch_ms() -> u128 {
     Utc::now().timestamp_millis() as u128
@@ -12,6 +11,7 @@ pub mod js_value {
     use js_sys::Reflect;
     use serde::de::DeserializeOwned;
     use serde::Serialize;
+    use serde::Serializer;
     use wasm_bindgen::JsValue;
 
     use crate::error::Error;
@@ -34,7 +34,8 @@ pub mod js_value {
 
     /// From serde to JsValue
     pub fn serialize(obj: &impl Serialize) -> Result<JsValue> {
-        serde_wasm_bindgen::to_value(&obj).map_err(Error::SerdeWasmBindgenError)
+	let serializer = serde_wasm_bindgen::Serializer::json_compatible();
+	serializer.serialize_some(&obj).map_err(Error::SerdeWasmBindgenError)
     }
 
     /// From JsValue to serde

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -34,8 +34,10 @@ pub mod js_value {
 
     /// From serde to JsValue
     pub fn serialize(obj: &impl Serialize) -> Result<JsValue> {
-	let serializer = serde_wasm_bindgen::Serializer::json_compatible();
-	serializer.serialize_some(&obj).map_err(Error::SerdeWasmBindgenError)
+        let serializer = serde_wasm_bindgen::Serializer::json_compatible();
+        serializer
+            .serialize_some(&obj)
+            .map_err(Error::SerdeWasmBindgenError)
     }
 
     /// From JsValue to serde

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rings-derive"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 authors = ["RND <dev@ringsnetwork.io>"]
 repository = "https://github.com/RingsNetwork/rings-node"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rings-node"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 default-run = "rings"
 authors = ["RND <dev@ringsnetwork.io>"]

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "RND <dev@ringsnetwork.io>"
   ],
   "description": "Rings is a structured peer-to-peer network implementation using WebRTC, Chord algorithm, and full WebAssembly (WASM) support.\n",
-  "version": "0.2.6",
+  "version": "0.3.2",
   "license": "GPL-3.0",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "RND <dev@ringsnetwork.io>"
   ],
   "description": "Rings is a structured peer-to-peer network implementation using WebRTC, Chord algorithm, and full WebAssembly (WASM) support.\n",
-  "version": "0.3.2",
+  "version": "0.3.4",
   "license": "GPL-3.0",
   "repository": {
     "type": "git",

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rings-rpc"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 authors = ["RND <dev@ringsnetwork.io>"]
 description = """

--- a/transport/Cargo.toml
+++ b/transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rings-transport"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 authors = ["RND <dev@ringsnetwork.io>"]
 description = "Transport layer implementation for Rings Core"


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## :large_blue_circle: What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
bugfix
## :brown_circle: What is the current behavior? (You can also link to an open issue here)

Currently the mapper of Rust -> JsValue is not JSON compatible.
Because Map can not be directly serialize in js.

## :green_circle: What is the new behavior (if this is a feature change)?

## :radioactive: Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

## :information_source: Other information

Closes #issue
