### PR TITLE
feature: move session_sk to a separate file in config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1985,6 +1985,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "http"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3401,7 +3410,7 @@ dependencies = [
 
 [[package]]
 name = "rings-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "arrayref",
  "async-channel",
@@ -3463,7 +3472,7 @@ dependencies = [
 
 [[package]]
 name = "rings-derive"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3474,7 +3483,7 @@ dependencies = [
 
 [[package]]
 name = "rings-node"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "arrayref",
@@ -3495,6 +3504,7 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "futures-timer",
+ "home",
  "http",
  "hyper",
  "js-sys",
@@ -3532,7 +3542,7 @@ dependencies = [
 
 [[package]]
 name = "rings-rpc"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "base64 0.13.1",
  "http",
@@ -3548,7 +3558,7 @@ dependencies = [
 
 [[package]]
 name = "rings-transport"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["core", "transport", "node", "rpc", "derive"]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "GPL-3.0"
 authors = ["RND <dev@ringsnetwork.io>"]

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -27,7 +27,7 @@
 //! let account_type = "secp256k1".to_string();
 //! let account_entity = user_secret_key_did.to_string();
 //!
-//! let mut builder = SessionSkBuilder::new(account_entity, account_type);
+//! let builder = SessionSkBuilder::new(account_entity, account_type);
 //! let unsigned_proof = builder.unsigned_proof();
 //!
 //! // Sign the unsigned proof with user's secret key.

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -44,6 +44,7 @@ node = [
     "rings-transport/native-webrtc",
     "wasmer/default",
     "wasmer-types",
+    "home",
 ]
 browser = [
     "backtrace",
@@ -99,6 +100,7 @@ axum = { version = "0.6.10", optional = true }
 backtrace = { version = "0.3.6", optional = true }
 clap = { version = "4.0.14", features = ["derive", "env"], optional = true }
 form_urlencoded = { version = "1.0.1", optional = true }
+home = { version = "0.5.5", optional = true }
 hyper = { version = "0.14.25", features = ["full"], optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 opentelemetry = { version = "0.18.0", default-features = false, features = ["trace", "rt-tokio"], optional = true }

--- a/node/src/error.rs
+++ b/node/src/error.rs
@@ -95,6 +95,10 @@ pub enum Error {
     OpenFileError(String) = 901,
     #[error("Acquire lock failed")]
     Lock = 902,
+    #[error("Cannot find home directory")]
+    HomeDirError = 903,
+    #[error("Cannot find parent directory")]
+    ParentDirError = 904,
     #[error("Serde json error: {0}")]
     SerdeJsonError(#[from] serde_json::Error) = 1000,
     #[error("Serde yaml error: {0}")]

--- a/node/src/util.rs
+++ b/node/src/util.rs
@@ -1,8 +1,8 @@
 //! Utilities for configuration and build.
 #![warn(missing_docs)]
 
+#[cfg(feature = "node")]
 use crate::error::Error;
-use crate::error::Result;
 
 /// build_version of program
 pub fn build_version() -> String {
@@ -18,7 +18,7 @@ pub fn build_version() -> String {
 
 /// Expand path with "~" to absolute path.
 #[cfg(feature = "node")]
-pub fn expand_home<P>(path: P) -> Result<std::path::PathBuf>
+pub fn expand_home<P>(path: P) -> Result<std::path::PathBuf, Error>
 where P: AsRef<std::path::Path> {
     let Ok(stripped) = path.as_ref().strip_prefix("~") else {
         return Ok(path.as_ref().to_path_buf());
@@ -35,7 +35,7 @@ where P: AsRef<std::path::Path> {
 
 /// Create parent directory of a path if not exists.
 #[cfg(feature = "node")]
-pub fn ensure_parent_dir<P>(path: P) -> Result<()>
+pub fn ensure_parent_dir<P>(path: P) -> Result<(), Error>
 where P: AsRef<std::path::Path> {
     let path = expand_home(path)?;
     let parent = path.parent().ok_or(Error::ParentDirError)?;
@@ -84,6 +84,7 @@ pub mod loader {
 }
 
 #[cfg(test)]
+#[cfg(feature = "node")]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

## :large_blue_circle: What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
This PR moves the session_sk dump from the config file to a separate session_sk file. It then uses the path of that file as a replacement.
Additionally, this PR adds a `new-session` subcommand in the rings bin, allowing users to refresh their session_sk or generate a new one.
However, it is important to note that users still need to restart the rings node after updating the session_sk file.

## :brown_circle: What is the current behavior? (You can also link to an open issue here)
Cannot generate a config file with template engine since the session_sk need rings bin to generate.
Cannot update session_sk without touch config file when its expired.

## :green_circle: What is the new behavior (if this is a feature change)?
The `session_sk` config is now a file path. Simply use `rings new-session` to generate it when needed.

## :radioactive: Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No breaking change.

## :information_source: Other information

Closes #issue
